### PR TITLE
Version boost

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: check-xml
       - id: detect-private-key
       - id: forbid-new-submodules
-      - id: forbid-submodules
+      # - id: forbid-submodules
       - id: mixed-line-ending
       - id: destroyed-symlinks
       - id: fix-byte-order-marker
@@ -59,7 +59,7 @@ repos:
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       # Run the linter.
       - id: ruff

--- a/albucore/__init__.py
+++ b/albucore/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 from .functions import *

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ pre_commit>=3.5.0
 pytest>=8.2.0
 pytest_cov>=4.1.0
 pytest_mock>=3.14.0
-ruff>=0.4.8
+ruff>=0.4.9
 tomli>=2.0.1
 types-setuptools


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the pre-commit configuration to use a newer version of Ruff (v0.4.9) and comments out the 'forbid-submodules' hook.

* **Build**:
    - Updated the pre-commit configuration to use Ruff version v0.4.9.
* **Chores**:
    - Commented out the 'forbid-submodules' pre-commit hook.

<!-- Generated by sourcery-ai[bot]: end summary -->