### PR TITLE
Added tests to check output shape and dtype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,6 @@ jobs:
         python -m pip install --upgrade pip uv
         uv pip install --system .
     - name: Install dev requirements
-      run: pip install --system -r requirements-dev.txt
+      run: uv pip install --system -r requirements-dev.txt
     - name: Run checks
       run: pre-commit run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install requirements
       run: |
-        python -m pip install --upgrade pip
-        pip install .
+        python -m pip install --upgrade pip uv
+        uv pip install --system .
     - name: Install dev requirements
-      run: pip install -r requirements-dev.txt
+      run: pip install --system -r requirements-dev.txt
     - name: Run checks
       run: pre-commit run

--- a/albucore/functions.py
+++ b/albucore/functions.py
@@ -171,6 +171,7 @@ def add_constant(img: np.ndarray, value: float) -> np.ndarray:
     return add_opencv(img, value)
 
 
+@clipped
 def add_vector(img: np.ndarray, value: np.ndarray) -> np.ndarray:
     if img.dtype == np.uint8:
         return add_lut(img, value)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -248,6 +248,10 @@ def test_add(img_dtype, num_channels, value, is_contiguous):
         assert np.array_equal(result_numpy, result_lut), f"Difference {(result_numpy - result_lut).mean()}"
 
     result = add(img, value)
+
+    assert result.dtype == img.dtype
+    assert result.shape == img.shape
+
     assert np.allclose(result, result_opencv, atol=1e-6), f"Difference {(result - result_opencv).max()}"
 
     assert np.array_equal(img, original_image), "Input image was modified"

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from albucore.functions import add_vector
 from albucore.utils import MAX_OPENCV_WORKING_CHANNELS, clip
 from albucore import (
     add_lut,

--- a/tests/test_add_weighted.py
+++ b/tests/test_add_weighted.py
@@ -163,6 +163,10 @@ def test_add_weighted_vs_add(img_dtype, num_channels, is_contiguous):
     original_img2 = img2.copy()
 
     result = add_weighted(img1, 1, img2, 1)
+
+    assert result.dtype == img1.dtype
+    assert result.shape == img1.shape
+
     result_add = add(img1, img2)
 
     assert np.array_equal(result, result_add)

--- a/tests/test_multiply.py
+++ b/tests/test_multiply.py
@@ -194,6 +194,9 @@ def test_multiply(img_dtype, num_channels, multiplier, is_contiguous):
 
     result = multiply(img, multiplier)
 
+    assert result.dtype == img.dtype
+    assert result.shape == img.shape
+
     result_numpy = clip(multiply_numpy(img, processed_multiplier), img.dtype)
 
     assert np.allclose(result, result_numpy, atol=1e-6)

--- a/tests/test_multiply_add.py
+++ b/tests/test_multiply_add.py
@@ -120,6 +120,9 @@ def test_multiply_add(img_dtype, num_channels, value, factor, is_contiguous):
 
     result = multiply_add(img, factor, value)
 
+    assert result.shape == original_img.shape
+    assert result.dtype == original_img.dtype
+
     assert np.array_equal(img, original_img), "Input img was modified"
 
     result_numpy = clip(multiply_add_numpy(img, factor, value), img_dtype)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -86,5 +86,9 @@ def test_normalize(dtype, shape) -> None:
     mean = np.array(50, dtype=np.float32)
     denominator = np.array(1 / 3, dtype=np.float32)
     normalized = normalize(img, mean=mean, denominator=denominator)
+
+    assert normalized.shape == img.shape
+    assert normalized.dtype == np.float32
+
     expected = (np.ones(img.shape, dtype=np.float32) * 0.4 - 50) / 3
     assert_array_almost_equal_nulp(normalized, expected)

--- a/tests/test_normalize_per_image.py
+++ b/tests/test_normalize_per_image.py
@@ -92,6 +92,9 @@ def test_normalize_per_image(shape, normalization, dtype):
     # Normalize the image
     normalized_img = normalize_per_image(img, normalization)
 
+    assert normalized_img.dtype == np.float32, "Output dtype should be float32"
+    assert normalized_img.shape == img.shape, "Output shape should match input shape"
+
     # Assert the output shape matches the input shape
     assert normalized_img.shape == img.shape, "Output shape should match input shape"
     assert normalized_img.dtype == np.float32, "Output dtype should be float32"

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -94,8 +94,8 @@ def test_power(img_dtype, num_channels, exponent, is_contiguous):
     processed_exponent = convert_value(exponent, num_channels)
 
     result = power(img, exponent)
-
     assert result.shape == original_image.shape
+    assert result.dtype == original_image.dtype
 
     result_numpy = clip(power_numpy(img, processed_exponent), img_dtype)
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow to use 'uv' for pip installations and adds assertions in multiple test cases to check the output shape and dtype, ensuring consistency and correctness of the functions being tested.

- **CI**:
    - Updated CI workflow to use 'uv' for pip installations and added '--system' flag for installing dependencies.
- **Tests**:
    - Added assertions to check the output shape and dtype in various test cases for functions like add, add_weighted, normalize, multiply, multiply_add, normalize_per_image, and power.

<!-- Generated by sourcery-ai[bot]: end summary -->