### PR TITLE
Contigous checks output as well

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,13 @@ repos:
   #   hooks:
   #     - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.1.3"
+    rev: "2.2.0"
     hooks:
       - id: pyproject-fmt
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.10
+    rev: v0.5.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -68,7 +68,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.11.0
     hooks:
       - id: mypy
         files: ^albucore/

--- a/albucore/__init__.py
+++ b/albucore/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from .functions import *

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -147,12 +147,16 @@ def is_multispectral_image(image: np.ndarray) -> bool:
 def contiguous(
     func: Callable[Concatenate[np.ndarray, P], np.ndarray],
 ) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
-    """Ensure that input img is contiguous."""
+    """Ensure that input img is contiguous and the output array is also contiguous."""
 
     @wraps(func)
     def wrapped_function(img: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
+        # Ensure the input array is contiguous
         img = np.require(img, requirements=["C_CONTIGUOUS"])
-        return func(img, *args, **kwargs)
+        # Call the original function with the contiguous input
+        result = func(img, *args, **kwargs)
+        # Ensure the output array is contiguous
+        return np.require(result, requirements=["C_CONTIGUOUS"])
 
     return wrapped_function
 

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -156,7 +156,10 @@ def contiguous(
         # Call the original function with the contiguous input
         result = func(img, *args, **kwargs)
         # Ensure the output array is contiguous
-        return np.require(result, requirements=["C_CONTIGUOUS"])
+        if not result.flags["C_CONTIGUOUS"]:
+            return np.require(result, requirements=["C_CONTIGUOUS"])
+
+        return result
 
     return wrapped_function
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-mypy>=1.10.0
+mypy>=1.11.0
 pre_commit>=3.5.0
 pytest>=8.2.0
 pytest_cov>=4.1.0
 pytest_mock>=3.14.0
-ruff>=0.4.10
+ruff>=0.5.5
 tomli>=2.0.1
 types-setuptools

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 import cv2
-from albucore.utils import MAX_VALUES_BY_DTYPE, NPDTYPE_TO_OPENCV_DTYPE, clip, convert_value, get_opencv_dtype_from_numpy
-import albucore
+from albucore.utils import NPDTYPE_TO_OPENCV_DTYPE, clip, convert_value, get_opencv_dtype_from_numpy, contiguous
 
 
 @pytest.mark.parametrize("input_img, dtype, expected", [
@@ -54,3 +53,36 @@ def test_convert_value(value, num_channels, expected):
         assert np.array_equal(result, expected)
     else:
          assert result == expected
+
+@contiguous
+def process_image(img: np.ndarray) -> np.ndarray:
+    # For demonstration, let's just return a non-contiguous view
+    return img[::-1, ::-1]
+
+@pytest.mark.parametrize(
+    "input_array, expected_strides",
+    [
+        (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), (24, 8)),  # C-contiguous array
+        (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])[::-1, ::-1], (24, 8)),  # Non-contiguous view
+        (np.arange(100).reshape(10, 10), (80, 8)),  # Another C-contiguous array
+         (np.ones([3, 100, 100], dtype=np.uint8).transpose(1, 2, 0), (300, 3, 1))  # 3D array with transpose
+    ]
+)
+def test_contiguous_decorator(input_array, expected_strides):
+    # Check if input is made contiguous
+    contiguous_input = np.require(input_array, requirements=["C_CONTIGUOUS"])
+    input_strides_after = contiguous_input.strides
+
+    assert contiguous_input.flags["C_CONTIGUOUS"], "Input array is not C-contiguous"
+    assert input_strides_after == expected_strides, "Input array strides are not as expected"
+
+    # Process the array using the decorated function
+    output_array = process_image(input_array)
+
+    # Check if output is contiguous
+    assert output_array.flags["C_CONTIGUOUS"], "Output array is not C-contiguous"
+    assert output_array.strides == expected_strides, "Output array strides are not as expected"
+
+    # Check if the content is correct (same as reversing the original array)
+    expected_output = input_array[::-1, ::-1]
+    assert np.array_equal(output_array, expected_output), "Output array content is not as expected"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,11 @@ def test_contiguous_decorator(input_array):
     # Check if output is contiguous
     assert output_array.flags["C_CONTIGUOUS"], "Output array is not C-contiguous"
 
+    non_contiguous_array = np.asfortranarray(input_array)
+
+    output_array = process_image(non_contiguous_array)
+    assert output_array.flags["C_CONTIGUOUS"], "Output array is not C-contiguous"
+
     # Check if the content is correct (same as reversing the original array)
     expected_output = input_array[::-1, ::-1]
-    assert np.array_equal(output_array, expected_output), "Output array content is not as expected"
+    np.testing.assert_array_equal(output_array, expected_output), "Output array content is not as expected"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,28 +60,25 @@ def process_image(img: np.ndarray) -> np.ndarray:
     return img[::-1, ::-1]
 
 @pytest.mark.parametrize(
-    "input_array, expected_strides",
+    "input_array",
     [
-        (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), (24, 8)),  # C-contiguous array
-        (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])[::-1, ::-1], (24, 8)),  # Non-contiguous view
-        (np.arange(100).reshape(10, 10), (80, 8)),  # Another C-contiguous array
-         (np.ones([3, 100, 100], dtype=np.uint8).transpose(1, 2, 0), (300, 3, 1))  # 3D array with transpose
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),  # C-contiguous array
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])[::-1, ::-1],  # Non-contiguous view
+        np.arange(100).reshape(10, 10),  # Another C-contiguous array
+        np.ones([3, 100, 100], dtype=np.uint8).transpose(1, 2, 0)  # 3D array with transpose
     ]
 )
-def test_contiguous_decorator(input_array, expected_strides):
+def test_contiguous_decorator(input_array):
     # Check if input is made contiguous
     contiguous_input = np.require(input_array, requirements=["C_CONTIGUOUS"])
-    input_strides_after = contiguous_input.strides
 
     assert contiguous_input.flags["C_CONTIGUOUS"], "Input array is not C-contiguous"
-    assert input_strides_after == expected_strides, "Input array strides are not as expected"
 
     # Process the array using the decorated function
     output_array = process_image(input_array)
 
     # Check if output is contiguous
     assert output_array.flags["C_CONTIGUOUS"], "Output array is not C-contiguous"
-    assert output_array.strides == expected_strides, "Output array strides are not as expected"
 
     # Check if the content is correct (same as reversing the original array)
     expected_output = input_array[::-1, ::-1]


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the `contiguous` decorator to ensure that both input and output arrays are contiguous. It also updates several pre-commit hooks to their latest versions and adds tests to verify the functionality of the updated decorator.

- **Enhancements**:
    - Enhanced the `contiguous` decorator to ensure that both input and output arrays are contiguous.
- **Build**:
    - Updated pre-commit hooks: pyproject-fmt to version 2.2.0, ruff-pre-commit to version 0.5.5, and mypy to version 1.11.0.
- **Tests**:
    - Added tests to verify that the `contiguous` decorator ensures both input and output arrays are contiguous.

<!-- Generated by sourcery-ai[bot]: end summary -->