### PR TITLE
Added decorator to show way to process data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.5
+    rev: v0.6.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/albucore/__init__.py
+++ b/albucore/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 
+from .decorators import *
 from .functions import *
 from .utils import *

--- a/albucore/decorators.py
+++ b/albucore/decorators.py
@@ -1,0 +1,51 @@
+import sys
+from functools import wraps
+from typing import Callable
+
+import numpy as np
+
+from albucore.utils import MONO_CHANNEL_DIMENSIONS, NUM_MULTI_CHANNEL_DIMENSIONS, P
+
+if sys.version_info >= (3, 10):
+    from typing import Concatenate
+else:
+    from typing_extensions import Concatenate
+
+
+def contiguous(
+    func: Callable[Concatenate[np.ndarray, P], np.ndarray],
+) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
+    """Ensure that input img is contiguous and the output array is also contiguous."""
+
+    @wraps(func)
+    def wrapped_function(img: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
+        # Ensure the input array is contiguous
+        img = np.require(img, requirements=["C_CONTIGUOUS"])
+        # Call the original function with the contiguous input
+        result = func(img, *args, **kwargs)
+        # Ensure the output array is contiguous
+        if not result.flags["C_CONTIGUOUS"]:
+            return np.require(result, requirements=["C_CONTIGUOUS"])
+
+        return result
+
+    return wrapped_function
+
+
+def preserve_channel_dim(
+    func: Callable[Concatenate[np.ndarray, P], np.ndarray],
+) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
+    """Preserve dummy channel dim."""
+
+    @wraps(func)
+    def wrapped_function(img: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
+        shape = img.shape
+        result = func(img, *args, **kwargs)
+        if len(shape) == NUM_MULTI_CHANNEL_DIMENSIONS and shape[-1] == 1 and result.ndim == MONO_CHANNEL_DIMENSIONS:
+            return np.expand_dims(result, axis=-1)
+
+        if len(shape) == MONO_CHANNEL_DIMENSIONS and result.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
+            return result[:, :, 0]
+        return result
+
+    return wrapped_function

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -109,25 +109,6 @@ def clipped(func: Callable[Concatenate[np.ndarray, P], np.ndarray]) -> Callable[
     return wrapped_function
 
 
-def preserve_channel_dim(
-    func: Callable[Concatenate[np.ndarray, P], np.ndarray],
-) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
-    """Preserve dummy channel dim."""
-
-    @wraps(func)
-    def wrapped_function(img: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
-        shape = img.shape
-        result = func(img, *args, **kwargs)
-        if len(shape) == NUM_MULTI_CHANNEL_DIMENSIONS and shape[-1] == 1 and result.ndim == MONO_CHANNEL_DIMENSIONS:
-            return np.expand_dims(result, axis=-1)
-
-        if len(shape) == MONO_CHANNEL_DIMENSIONS and result.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
-            return result[:, :, 0]
-        return result
-
-    return wrapped_function
-
-
 def get_num_channels(image: np.ndarray) -> int:
     return image.shape[2] if image.ndim == NUM_MULTI_CHANNEL_DIMENSIONS else 1
 
@@ -149,26 +130,6 @@ def is_rgb_image(image: np.ndarray) -> bool:
 def is_multispectral_image(image: np.ndarray) -> bool:
     num_channels = get_num_channels(image)
     return num_channels not in {1, 3}
-
-
-def contiguous(
-    func: Callable[Concatenate[np.ndarray, P], np.ndarray],
-) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
-    """Ensure that input img is contiguous and the output array is also contiguous."""
-
-    @wraps(func)
-    def wrapped_function(img: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
-        # Ensure the input array is contiguous
-        img = np.require(img, requirements=["C_CONTIGUOUS"])
-        # Call the original function with the contiguous input
-        result = func(img, *args, **kwargs)
-        # Ensure the output array is contiguous
-        if not result.flags["C_CONTIGUOUS"]:
-            return np.require(result, requirements=["C_CONTIGUOUS"])
-
-        return result
-
-    return wrapped_function
 
 
 def convert_value(value: np.ndarray | float, num_channels: int) -> float | np.ndarray:

--- a/tests/test_to_from_float.py
+++ b/tests/test_to_from_float.py
@@ -324,3 +324,23 @@ def test_from_float_opencv_input_unchanged(dtype, channels):
     img_copy = img.copy()
     _ = from_float_opencv(img, dtype, max_value)
     np.testing.assert_array_equal(img, img_copy)
+
+
+def test_to_float_returns_same_object_for_float32():
+    float32_image = np.random.rand(10, 10, 3).astype(np.float32)
+    result = to_float(float32_image)
+    assert result is float32_image  # Check if it's the same object
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.float32])
+def test_to_float_from_float_roundtrip(dtype):
+    if dtype == np.float32:
+        original = np.random.rand(10, 10, 3).astype(dtype)
+    else:
+        original = np.random.randint(0, 256, (10, 10, 3)).astype(dtype)
+
+    float_version = to_float(original)
+    roundtrip = from_float(float_version, dtype)
+
+    assert roundtrip.dtype == dtype
+    np.testing.assert_allclose(original, roundtrip, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add decorators to ensure consistent data types for image processing functions and optimize data type handling in conversion functions. Update tests to cover new decorators and improve pre-commit configuration.

New Features:
- Introduce `float32_io` and `uint8_io` decorators to ensure consistent input/output data types for image processing functions, converting images to float32 or uint8 as needed.

Enhancements:
- Optimize `to_float` and `from_float` functions to handle float32 and float64 data types more efficiently by avoiding unnecessary conversions.

Build:
- Update the pre-commit configuration to use Ruff version v0.6.6.

Tests:
- Add tests for the new `float32_io` and `uint8_io` decorators to verify that they correctly handle data type conversions and preserve the original data type.
- Add tests to ensure that `to_float` returns the same object for float32 inputs and that `to_float` and `from_float` functions maintain data integrity through round-trip conversions.

Chores:
- Move `contiguous` and `preserve_channel_dim` decorators to a new `decorators.py` file for better organization.

<!-- Generated by sourcery-ai[bot]: end summary -->