### PR TITLE
4x Faster LUT via StringZilla

### DIFF
--- a/benchmark/requirements.in
+++ b/benchmark/requirements.in
@@ -1,6 +1,7 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 
 numpy
+stringzilla
 opencv-python-headless
 tqdm
 pandas

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -52,6 +52,8 @@ pytz==2024.2
 setuptools==74.1.2
     # via pytablewriter
 six==1.16.0
+    # via pandas
+stringzilla==5.10.0
     # via python-dateutil
 sympy==1.13.2
     # via torch
@@ -75,4 +77,4 @@ typepy==1.3.2
 typing-extensions==4.12.2
     # via torch
 tzdata==2024.1
-    # via pandas
+    # via -r requirements.in


### PR DESCRIPTION
StringZilla brings hardware-accelerated Look-Up Table transformations that can leverage AVX-512 VBMI instructions on recent Intel Ice Lake CPUs (installed in most DGX servers), as well as older Intel Haswell, and newer Arm CPUs, like AWS Graviton 4.

Preliminary benchmarks on new x86 CPUs suggest up to 4x performance improvements compared to the OpenCV baselines. The results will differ depending on the CPU model. I generally recommend using `r7iz` and `r8g` AWS instances for profiling.

## Summary by Sourcery

Implement a faster Look-Up Table transformation using StringZilla, which utilizes hardware acceleration on supported CPUs, replacing the existing OpenCV-based approach for significant performance gains.

New Features:
- Introduce hardware-accelerated Look-Up Table transformations using StringZilla, leveraging AVX-512 VBMI instructions on compatible CPUs.

Enhancements:
- Replace OpenCV LUT operations with a custom serialization-based approach for improved performance.