### PR TITLE
unpin stringzilla

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 INSTALL_REQUIRES = [
     "numpy>=1.24.4",
     "typing-extensions>=4.9.0; python_version<'3.10'",
-    "stringzilla==3.10.4",
+    "stringzilla>=3.10.4",
 
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Unpin the 'stringzilla' package version in the setup configuration, allowing for updates beyond version 3.10.4.