### PR TITLE
Add support for more than 512 channels in horizontal flip

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: python-use-type-annotations
       - id: text-unicode-replacement-char
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"]
@@ -53,13 +53,13 @@ repos:
   #   hooks:
   #     - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.0"
+    rev: "v2.5.1"
     hooks:
       - id: pyproject-fmt
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.4
+    rev: v0.9.10
     hooks:
       # Run the linter.
       - id: ruff
@@ -68,7 +68,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         files: ^(albucore|benchmark)/

--- a/albucore/functions.py
+++ b/albucore/functions.py
@@ -32,10 +32,10 @@ def add_weighted_simsimd(img1: np.ndarray, weight1: float, img2: np.ndarray, wei
     original_dtype = img1.dtype
 
     if img2.dtype != original_dtype:
-        img2 = clip(img2.astype(original_dtype), original_dtype, inplace=True)
+        img2 = clip(img2.astype(original_dtype, copy=False), original_dtype, inplace=True)
 
     return np.frombuffer(
-        ss.wsum(img1.reshape(-1), img2.astype(original_dtype).reshape(-1), alpha=weight1, beta=weight2),
+        ss.wsum(img1.reshape(-1), img2.astype(original_dtype, copy=False).reshape(-1), alpha=weight1, beta=weight2),
         dtype=original_dtype,
     ).reshape(
         original_shape,
@@ -51,7 +51,7 @@ def multiply_by_constant_simsimd(img: np.ndarray, value: float) -> np.ndarray:
 
 
 def add_constant_simsimd(img: np.ndarray, value: float) -> np.ndarray:
-    return add_weighted_simsimd(img, 1, (np.ones_like(img) * value).astype(img.dtype), 1)
+    return add_weighted_simsimd(img, 1, (np.ones_like(img) * value).astype(img.dtype, copy=False), 1)
 
 
 def create_lut_array(
@@ -135,14 +135,14 @@ def _prepare_array_value(
     operation: Literal["add", "multiply"],
 ) -> np.ndarray:
     if value.dtype == np.float64:
-        value = value.astype(np.float32)
+        value = value.astype(np.float32, copy=False)
     if value.ndim == 1:
         value = value.reshape(1, 1, -1)
     value = np.broadcast_to(value, img.shape)
     if operation == "add" and img.dtype == np.uint8:
         if np.all(value >= 0):
             return clip(value, np.uint8)
-        return np.trunc(value).astype(np.float32)
+        return np.trunc(value).astype(np.float32, copy=False)
     return value
 
 
@@ -154,7 +154,7 @@ def apply_numpy(
     if operation == "add" and img.dtype == np.uint8:
         value = np.int16(value)
 
-    return np_operations[operation](img.astype(np.float32), value)
+    return np_operations[operation](img.astype(np.float32, copy=False), value)
 
 
 def multiply_lut(img: np.ndarray, value: np.ndarray | float, inplace: bool) -> np.ndarray:
@@ -165,7 +165,7 @@ def multiply_lut(img: np.ndarray, value: np.ndarray | float, inplace: bool) -> n
 def multiply_opencv(img: np.ndarray, value: np.ndarray | float) -> np.ndarray:
     value = prepare_value_opencv(img, value, "multiply")
     if img.dtype == np.uint8:
-        return cv2.multiply(img.astype(np.float32), value)
+        return cv2.multiply(img.astype(np.float32, copy=False), value)
     return cv2.multiply(img, value)
 
 
@@ -223,7 +223,10 @@ def add_opencv(img: np.ndarray, value: np.ndarray | float, inplace: bool = False
     )
 
     if needs_float:
-        return cv2.add(img.astype(np.float32), value if isinstance(value, (int, float)) else value.astype(np.float32))
+        return cv2.add(
+            img.astype(np.float32, copy=False),
+            value if isinstance(value, (int, float)) else value.astype(np.float32, copy=False),
+        )
 
     # Use img as the destination array if inplace=True
     dst = img if inplace else None
@@ -272,14 +275,14 @@ def add(img: np.ndarray, value: ValueType, inplace: bool = False) -> np.ndarray:
 
 
 def normalize_numpy(img: np.ndarray, mean: float | np.ndarray, denominator: float | np.ndarray) -> np.ndarray:
-    img = img.astype(np.float32)
+    img = img.astype(np.float32, copy=False)
     img -= mean
     return img * denominator
 
 
 @preserve_channel_dim
 def normalize_opencv(img: np.ndarray, mean: float | np.ndarray, denominator: float | np.ndarray) -> np.ndarray:
-    img = img.astype(np.float32)
+    img = img.astype(np.float32, copy=False)
     mean_img = np.zeros_like(img, dtype=np.float32)
     denominator_img = np.zeros_like(img, dtype=np.float32)
 
@@ -290,7 +293,7 @@ def normalize_opencv(img: np.ndarray, mean: float | np.ndarray, denominator: flo
         denominator = np.full(img.shape, denominator, dtype=np.float32)
 
     # Ensure the shapes match for broadcasting
-    mean_img = (mean_img + mean).astype(np.float32)
+    mean_img = (mean_img + mean).astype(np.float32, copy=False)
     denominator_img = denominator_img + denominator
 
     result = cv2.subtract(img, mean_img)
@@ -343,7 +346,7 @@ def power_opencv(img: np.ndarray, value: float) -> np.ndarray:
         return cv2.pow(img, value)
     if img.dtype == np.uint8 and isinstance(value, float):
         # For uint8 images, convert to float32, apply power, then convert back to uint8
-        img_float = img.astype(np.float32)
+        img_float = img.astype(np.float32, copy=False)
         return cv2.pow(img_float, value)
 
     raise ValueError(f"Unsupported image type {img.dtype} for power operation with value {value}")
@@ -368,7 +371,7 @@ def power(img: np.ndarray, exponent: ValueType, inplace: bool = False) -> np.nda
 
 
 def add_weighted_numpy(img1: np.ndarray, weight1: float, img2: np.ndarray, weight2: float) -> np.ndarray:
-    return img1.astype(np.float32) * weight1 + img2.astype(np.float32) * weight2
+    return img1.astype(np.float32, copy=False) * weight1 + img2.astype(np.float32, copy=False) * weight2
 
 
 @preserve_channel_dim
@@ -430,7 +433,7 @@ def multiply_add_opencv(img: np.ndarray, factor: ValueType, value: ValueType) ->
     if isinstance(value, (int, float)) and value == 0 and isinstance(factor, (int, float)) and factor == 0:
         return np.zeros_like(img)
 
-    result = img.astype(np.float32)
+    result = img.astype(np.float32, copy=False)
     result = (
         cv2.multiply(result, np.ones_like(result) * factor, dtype=cv2.CV_64F)
         if factor != 0
@@ -473,7 +476,7 @@ def multiply_add(img: np.ndarray, factor: ValueType, value: ValueType, inplace: 
 
 @preserve_channel_dim
 def normalize_per_image_opencv(img: np.ndarray, normalization: NormalizationType) -> np.ndarray:
-    img = img.astype(np.float32)
+    img = img.astype(np.float32, copy=False)
     eps = 1e-4
 
     if img.ndim == MONO_CHANNEL_DIMENSIONS:
@@ -520,7 +523,7 @@ def normalize_per_image_opencv(img: np.ndarray, normalization: NormalizationType
 
 @preserve_channel_dim
 def normalize_per_image_numpy(img: np.ndarray, normalization: NormalizationType) -> np.ndarray:
-    img = img.astype(np.float32)
+    img = img.astype(np.float32, copy=False)
     eps = 1e-4
 
     if img.ndim == MONO_CHANNEL_DIMENSIONS:
@@ -604,7 +607,7 @@ def normalize_per_image(img: np.ndarray, normalization: NormalizationType) -> np
 def to_float_numpy(img: np.ndarray, max_value: float | None = None) -> np.ndarray:
     if max_value is None:
         max_value = get_max_value(img.dtype)
-    return (img / max_value).astype(np.float32)
+    return (img / max_value).astype(np.float32, copy=False)
 
 
 @preserve_channel_dim
@@ -612,7 +615,7 @@ def to_float_opencv(img: np.ndarray, max_value: float | None = None) -> np.ndarr
     if max_value is None:
         max_value = get_max_value(img.dtype)
 
-    img_float = img.astype(np.float32)
+    img_float = img.astype(np.float32, copy=False)
 
     num_channels = get_num_channels(img)
 
@@ -638,7 +641,7 @@ def to_float_lut(img: np.ndarray, max_value: float | None = None) -> np.ndarray:
 
 def to_float(img: np.ndarray, max_value: float | None = None) -> np.ndarray:
     if img.dtype == np.float64:
-        return img.astype(np.float32)
+        return img.astype(np.float32, copy=False)
     if img.dtype == np.float32:
         return img
     if img.dtype == np.uint8:
@@ -657,7 +660,7 @@ def from_float_opencv(img: np.ndarray, target_dtype: np.dtype, max_value: float 
     if max_value is None:
         max_value = get_max_value(target_dtype)
 
-    img_float = img.astype(np.float32)
+    img_float = img.astype(np.float32, copy=False)
 
     num_channels = get_num_channels(img)
 
@@ -695,7 +698,7 @@ def from_float(img: np.ndarray, target_dtype: np.dtype, max_value: float | None 
         return img
 
     if target_dtype == np.float64:
-        return img.astype(np.float32)
+        return img.astype(np.float32, copy=False)
 
     if img.dtype == np.float32:
         return from_float_opencv(img, target_dtype, max_value)
@@ -710,6 +713,9 @@ def hflip_numpy(img: np.ndarray) -> np.ndarray:
 
 @preserve_channel_dim
 def hflip_cv2(img: np.ndarray) -> np.ndarray:
+    # OpenCV's flip function has a limitation of 512 channels
+    if img.ndim > 2 and img.shape[2] > 512:
+        return _flip_multichannel(img, flip_code=1)
     return cv2.flip(img, 1)
 
 
@@ -719,6 +725,9 @@ def hflip(img: np.ndarray) -> np.ndarray:
 
 @preserve_channel_dim
 def vflip_cv2(img: np.ndarray) -> np.ndarray:
+    # OpenCV's flip function has a limitation of 512 channels
+    if img.ndim > 2 and img.shape[2] > 512:
+        return _flip_multichannel(img, flip_code=0)
     return cv2.flip(img, 0)
 
 
@@ -729,6 +738,48 @@ def vflip_numpy(img: np.ndarray) -> np.ndarray:
 
 def vflip(img: np.ndarray) -> np.ndarray:
     return vflip_cv2(img)
+
+
+def _flip_multichannel(img: np.ndarray, flip_code: int) -> np.ndarray:
+    """Process images with more than 512 channels by splitting into chunks.
+
+    OpenCV's flip function has a limitation where it can only handle images with up to 512 channels.
+    This function works around that limitation by splitting the image into chunks of 512 channels,
+    flipping each chunk separately, and then concatenating the results.
+
+    Args:
+        img: Input image with many channels
+        flip_code: OpenCV flip code (0 for vertical, 1 for horizontal, -1 for both)
+
+    Returns:
+        Flipped image with all channels preserved
+    """
+    # Get image dimensions
+    height, width = img.shape[:2]
+    num_channels = 1 if img.ndim == 2 else img.shape[2]
+
+    # If the image has 2 dimensions or fewer than 512 channels, use cv2.flip directly
+    if img.ndim == 2 or num_channels <= 512:
+        return cv2.flip(img, flip_code)
+
+    # Process in chunks of 512 channels
+    chunk_size = 512
+    result_chunks = []
+
+    for i in range(0, num_channels, chunk_size):
+        end_idx = min(i + chunk_size, num_channels)
+        chunk = img[:, :, i:end_idx]
+        flipped_chunk = cv2.flip(chunk, flip_code)
+
+        # Ensure the chunk maintains its dimensionality
+        # This is needed when the last chunk has only one channel and cv2.flip reduces the dimensions
+        if flipped_chunk.ndim == 2 and img.ndim == 3:
+            flipped_chunk = np.expand_dims(flipped_chunk, axis=2)
+
+        result_chunks.append(flipped_chunk)
+
+    # Concatenate the chunks along the channel dimension
+    return np.concatenate(result_chunks, axis=2)
 
 
 def float32_io(func: Callable[..., np.ndarray]) -> Callable[..., np.ndarray]:

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -77,7 +77,7 @@ def maybe_process_in_chunks(
     def __process_fn(img: np.ndarray, *process_args: P.args, **process_kwargs: P.kwargs) -> np.ndarray:
         # Merge args and kwargs
         all_args = (*args, *process_args)
-        all_kwargs: dict[str, Any] = {**kwargs, **process_kwargs}
+        all_kwargs: dict[str, Any] = kwargs | process_kwargs
 
         num_channels = get_num_channels(img)
         if num_channels > MAX_OPENCV_WORKING_CHANNELS:

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -77,7 +77,7 @@ def maybe_process_in_chunks(
     def __process_fn(img: np.ndarray, *process_args: P.args, **process_kwargs: P.kwargs) -> np.ndarray:
         # Merge args and kwargs
         all_args = (*args, *process_args)
-        all_kwargs: P.kwargs = {**kwargs, **process_kwargs}
+        all_kwargs: dict[str, Any] = {**kwargs, **process_kwargs}
 
         num_channels = get_num_channels(img)
         if num_channels > MAX_OPENCV_WORKING_CHANNELS:
@@ -105,7 +105,7 @@ def clip(img: np.ndarray, dtype: Any, inplace: bool = False) -> np.ndarray:
     max_value = MAX_VALUES_BY_DTYPE[dtype]
     if inplace:
         return np.clip(img, 0, max_value, out=img)
-    return np.clip(img, 0, max_value).astype(dtype)
+    return np.clip(img, 0, max_value).astype(dtype, copy=False)
 
 
 def clipped(func: Callable[Concatenate[np.ndarray, P], np.ndarray]) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "albucore"
-version = "0.0.23"
+version = "0.0.24"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"
@@ -101,38 +101,17 @@ format.skip-magic-trailing-comma = false
 # Like Black, automatically detect the appropriate line ending.
 lint.select = [ "ALL" ]
 lint.ignore = [
-  "ANN101",
-  "ANN102",
-  "ANN204",
   "ANN401",
   "ARG001",
-  "ARG002",
-  "B008",
-  "B027",
   "D100",
-  "D101",
-  "D102",
   "D103",
   "D104",
-  "D105",
-  "D106",
-  "D107",
-  "D205",
-  "D415",
   "EM101",
   "EM102",
   "F403",
   "FBT001",
   "FBT002",
-  "FBT003",
-  "G004",
-  "PLR0913",
   "PLR2004",
-  "PTH123",
-  "S311",
-  "TCH001",
-  "TCH002",
-  "TCH003",
   "TRY003",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ lint.ignore = [
   "F403",
   "FBT001",
   "FBT002",
+  "FBT003",
   "PLR2004",
   "TRY003",
 ]

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import cv2
-from albucore.functions import hflip_numpy, hflip_cv2, vflip, vflip_cv2, vflip_numpy
+from albucore.functions import hflip_numpy, hflip_cv2, vflip, vflip_cv2, vflip_numpy, hflip, _flip_multichannel
 
 @pytest.mark.parametrize("channels", [1, 3, 5])
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
@@ -92,3 +92,90 @@ def test_vflip_identity(shape, dtype):
     np.testing.assert_array_almost_equal(img, flipped_twice_numpy)
     np.testing.assert_array_almost_equal(img, flipped_twice_cv2)
     np.testing.assert_array_almost_equal(img, flipped_twice_main)
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_multichannel_hflip(dtype):
+    """Test horizontal flip with more than 512 channels."""
+    # Create a sample image with 600 channels (exceeds OpenCV's 512 channel limit)
+    channels = 600
+    height, width = 10, 15
+    img = np.arange(height * width * channels).reshape(height, width, channels).astype(dtype)
+
+    # Apply flip functions
+    flipped_numpy = hflip_numpy(img)
+    flipped_cv2 = hflip_cv2(img)
+    flipped_main = hflip(img)
+
+    # Test 1: Check if results match
+    np.testing.assert_array_equal(flipped_numpy, flipped_cv2)
+    np.testing.assert_array_equal(flipped_numpy, flipped_main)
+
+    # Test 2: Check if the flip is correct
+    expected = img[:, ::-1, :]
+    np.testing.assert_array_equal(flipped_numpy, expected)
+
+    # Test 3: Check if results are contiguous
+    assert flipped_cv2.flags['C_CONTIGUOUS']
+    assert flipped_main.flags['C_CONTIGUOUS']
+
+    # Test 4: Check if dtype is preserved
+    assert flipped_cv2.dtype == img.dtype
+    assert flipped_main.dtype == img.dtype
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_multichannel_vflip(dtype):
+    """Test vertical flip with more than 512 channels."""
+    # Create a sample image with 600 channels (exceeds OpenCV's 512 channel limit)
+    channels = 600
+    height, width = 10, 15
+    img = np.arange(height * width * channels).reshape(height, width, channels).astype(dtype)
+
+    # Apply flip functions
+    flipped_numpy = vflip_numpy(img)
+    flipped_cv2 = vflip_cv2(img)
+    flipped_main = vflip(img)
+
+    # Test 1: Check if results match
+    np.testing.assert_array_equal(flipped_numpy, flipped_cv2)
+    np.testing.assert_array_equal(flipped_numpy, flipped_main)
+
+    # Test 2: Check if the flip is correct
+    expected = img[::-1, :, :]
+    np.testing.assert_array_equal(flipped_numpy, expected)
+
+    # Test 3: Check if results are contiguous
+    assert flipped_cv2.flags['C_CONTIGUOUS']
+    assert flipped_main.flags['C_CONTIGUOUS']
+
+    # Test 4: Check if dtype is preserved
+    assert flipped_cv2.dtype == img.dtype
+    assert flipped_main.dtype == img.dtype
+
+
+@pytest.mark.parametrize("channels", [513, 600, 1024])
+@pytest.mark.parametrize("flip_code", [0, 1, -1])
+def test_flip_multichannel_function(channels, flip_code):
+    """Test the _flip_multichannel function directly with different channel counts and flip codes."""
+    height, width = 8, 10
+    img = np.arange(height * width * channels).reshape(height, width, channels).astype(np.float32)
+
+    # Apply the multichannel flip function
+    flipped = _flip_multichannel(img, flip_code)
+
+    # Determine expected result based on flip_code
+    if flip_code == 0:  # vertical flip
+        expected = img[::-1, :, :]
+    elif flip_code == 1:  # horizontal flip
+        expected = img[:, ::-1, :]
+    else:  # both
+        expected = img[::-1, ::-1, :]
+
+    # Check if the result matches the expected output
+    np.testing.assert_array_equal(flipped, expected)
+
+    # Check if the result is contiguous
+    assert flipped.flags['C_CONTIGUOUS']
+
+    # Check if dtype is preserved
+    assert flipped.dtype == img.dtype


### PR DESCRIPTION
## Summary by Sourcery

Implements support for horizontal and vertical flips of images with more than 512 channels, which addresses a limitation in OpenCV's flip function. The implementation splits the image into chunks, processes each chunk, and concatenates the results.

Tests:
- Adds tests for horizontal and vertical flips with more than 512 channels to ensure correct behavior and contiguous output.
- Adds tests for the `_flip_multichannel` function to verify its correctness with different channel counts and flip codes.