### PR TITLE
Add unit tests for to/from_float for image batches

### DIFF
--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -103,8 +103,8 @@ def maybe_process_in_chunks(
 
 def clip(img: np.ndarray, dtype: Any, inplace: bool = False) -> np.ndarray:
     max_value = MAX_VALUES_BY_DTYPE[dtype]
-    if inplace:
-        return np.clip(img, 0, max_value, out=img)
+    if inplace and img.dtype == dtype:
+        return np.clip(img, 0, max_value, out=img).astype(dtype, copy=False)
     return np.clip(img, 0, max_value).astype(dtype, copy=False)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,9 +10,11 @@ from albucore.utils import NPDTYPE_TO_OPENCV_DTYPE, clip, convert_value, get_ope
     (np.array([[-300, 0], [100, 400]], dtype=np.float32), np.uint8, np.array([[0, 0], [100, 255]], dtype=np.float32)),
     (np.array([[-0.02, 0], [0.5, 2.2]], dtype=np.float32), np.float32, np.array([[0, 0], [0.5, 1.0]], dtype=np.float32))
 ])
-def test_clip(input_img, dtype, expected):
-    clipped = clip(input_img, dtype=dtype)
+@pytest.mark.parametrize("inplace", [False, True])
+def test_clip(input_img, dtype, expected, inplace):
+    clipped = clip(input_img, dtype=dtype, inplace=inplace)
     np.testing.assert_array_equal(clipped, expected)
+    assert clipped.dtype == dtype
 
 valid_cv2_types = {
     cv2.CV_8U, cv2.CV_16U, cv2.CV_32F, cv2.CV_64F, cv2.CV_32S


### PR DESCRIPTION
The original purpose of this PR was to adapt `to_float` and `from_float` methods to work not only with images but also volumes, in preparation for a PR to `albumenations` to support `apply_to_images` for these corresponding augmentations. It turns out these functions already work with volumes, so I added explicit unit test coverage for this case, i.e., batch of images. While doing this, I came across two other issues that needed addressing.

### Redundant and hidden unit tests in `test_to_from_float.py`

There were duplicate tests in `test_to_from_float.py`, falling into two categories

- The same test name was used twice in the file, e.g., `test_from_float_numpy_vs_opencv`, which resulted in the first test not being executed at all (because the function was redefined). The tests were almost the same, with some small differences.
- Very similar names were used to test the same functionality, e.g., `test_from_float_input_unchanged` and `test_from_float_does_not_modify_input`.

In both cases, I removed one set of tests and where the tests were not exactly the same, I tried to use the more comprehensive version.

### `clip`

The function `clip`, when used with `inplace=True` was not returning the correct `dtype`. In retrospect, this is not surprising, because `inplace=True` is not compatible with dtype conversions. And so the question is, which should take precedence. Before, `inplace` was taking precedence, and when `inplace=True`, then the `dtype` parameter was being ignored.

This did lead to a unit test failure in `tests_to_from_float.py::test_from_float_numpy_vs_opencv`, but this failure was masked, because there was another test with the same name defined further below in the file (effectively over-writing the earlier test).

I changed the priority of parameters, so that now `dtype` is always respected and `inplace` is sometimes ignored. This is also not ideal, so maybe the right solution should be to raise an exception in that case, i.e.,

```
if inplace and img.dtype != dtype:
    raise ValueError(
        "Cannot perform inplace clipping, if dtypes are not the same. "
        f"img.dtype={dtype}, result.dtype={dtype}."
    )
```

## Summary by Sourcery

Refactor and extend unit tests for to_float/from_float to cover batched image and volume inputs, remove redundant tests, and fix dtype handling in clip when used inplace

Bug Fixes:
- Ensure clip respects the specified dtype even when inplace=True instead of ignoring dtype

Enhancements:
- Remove duplicate and overlapping tests in test_to_from_float.py

Tests:
- Parameterize to_float/from_float tests with a batch dimension and introduce a generate_img helper for image/volume creation
- Add immutability tests for to_float_opencv to verify inputs remain unmodified
- Extend clip tests to cover both inplace modes and assert correct output dtype