### PR TITLE
typo fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,13 @@ repos:
   #   hooks:
   #     - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.1"
+    rev: "v2.6.0"
     hooks:
       - id: pyproject-fmt
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.10
+    rev: v0.11.11
     hooks:
       # Run the linter.
       - id: ruff

--- a/albucore/decorators.py
+++ b/albucore/decorators.py
@@ -481,6 +481,6 @@ def batch_transform(
                 keep_depth_dim,
             )
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     return decorator


### PR DESCRIPTION
## Summary by Sourcery

Clean up code, update pre-commit hooks, and fix typing usage in decorators

Enhancements:
- Remove unused import and refactor generate_img to a single inline return
- Adjust cast call in decorators to use a string literal for the generic type

CI:
- Bump pyproject-fmt hook to v2.6.0
- Bump ruff pre-commit hook to v0.11.11