### PR TITLE
set spatial_axes to default values

### DIFF
--- a/albucore/functions.py
+++ b/albucore/functions.py
@@ -476,7 +476,39 @@ def multiply_add(img: np.ndarray, factor: ValueType, value: ValueType, inplace: 
 
 
 @preserve_channel_dim
-def normalize_per_image_opencv(img: np.ndarray, normalization: NormalizationType, spatial_axes: tuple[int, ...] = (0, 1)) -> np.ndarray:
+def normalize_per_image_opencv(
+    img: np.ndarray,
+    normalization: NormalizationType,
+    spatial_axes: tuple[int, ...] = (0, 1),
+) -> np.ndarray:
+    """Normalize an image using OpenCV operations based on the specified normalization type.
+
+    This function normalizes an image using various strategies, optimized with OpenCV operations
+    for better performance on standard image types.
+
+    Args:
+        img: Input image as a numpy array. Can be 2D (grayscale) or 3D (multi-channel).
+        normalization: Type of normalization to apply. Options are:
+            - "image": Normalize using global mean and std across all pixels
+            - "image_per_channel": Normalize each channel separately using its own mean and std
+            - "min_max": Scale to [0, 1] using global min and max values
+            - "min_max_per_channel": Scale each channel to [0, 1] using per-channel min and max
+        spatial_axes: Axes over which to compute statistics (default: (0, 1) for height and width).
+            Used for per-channel normalizations to determine which dimensions are spatial vs channel.
+
+    Returns:
+        Normalized image as float32 array with values clipped to [-20, 20] range to prevent
+        extreme values that could cause training instability.
+
+    Raises:
+        ValueError: If an unknown normalization method is specified.
+
+    Notes:
+        - The function automatically converts input to float32
+        - Adds epsilon (1e-4) to std deviation to prevent division by zero
+        - For images with >4 channels, falls back to array operations as OpenCV has limitations
+        - Single channel images treated as "image" normalization when "image_per_channel" is specified
+    """
     img = img.astype(np.float32, copy=False)
     eps = 1e-4
 
@@ -528,7 +560,39 @@ def normalize_per_image_opencv(img: np.ndarray, normalization: NormalizationType
 
 
 @preserve_channel_dim
-def normalize_per_image_numpy(img: np.ndarray, normalization: NormalizationType, spatial_axes: tuple[int, ...] = (0, 1)) -> np.ndarray:
+def normalize_per_image_numpy(
+    img: np.ndarray,
+    normalization: NormalizationType,
+    spatial_axes: tuple[int, ...] = (0, 1),
+) -> np.ndarray:
+    """Normalize an image using pure NumPy operations based on the specified normalization type.
+
+    This function provides the same normalization strategies as normalize_per_image_opencv but uses
+    pure NumPy operations. This can be useful for compatibility or when OpenCV is not available.
+
+    Args:
+        img: Input image as a numpy array. Can be 2D (grayscale) or 3D (multi-channel).
+        normalization: Type of normalization to apply. Options are:
+            - "image": Normalize using global mean and std across all pixels
+            - "image_per_channel": Normalize each channel separately using its own mean and std
+            - "min_max": Scale to [0, 1] using global min and max values
+            - "min_max_per_channel": Scale each channel to [0, 1] using per-channel min and max
+        spatial_axes: Axes over which to compute statistics (default: (0, 1) for height and width).
+            Used for per-channel normalizations to determine which dimensions are spatial vs channel.
+
+    Returns:
+        Normalized image as float32 array with values clipped to [-20, 20] range to prevent
+        extreme values that could cause training instability.
+
+    Raises:
+        ValueError: If an unknown normalization method is specified.
+
+    Notes:
+        - The function automatically converts input to float32
+        - Adds epsilon (1e-4) to std deviation to prevent division by zero
+        - Uses in-place operations where possible for memory efficiency
+        - Generally slower than the OpenCV version but more portable
+    """
     img = img.astype(np.float32, copy=False)
     eps = 1e-4
 
@@ -561,7 +625,40 @@ def normalize_per_image_numpy(img: np.ndarray, normalization: NormalizationType,
 
 
 @preserve_channel_dim
-def normalize_per_image_lut(img: np.ndarray, normalization: NormalizationType, spatial_axes: tuple[int, ...] = (0, 1)) -> np.ndarray:
+def normalize_per_image_lut(
+    img: np.ndarray,
+    normalization: NormalizationType,
+    spatial_axes: tuple[int, ...] = (0, 1),
+) -> np.ndarray:
+    """Normalize an image using lookup tables (LUT) for optimized performance on uint8 images.
+
+    This function implements the same normalization strategies but uses pre-computed lookup tables
+    for extremely fast normalization of uint8 images. This is the fastest method for uint8 data.
+
+    Args:
+        img: Input image as a numpy array with uint8 dtype. Can be 2D (grayscale) or 3D (multi-channel).
+        normalization: Type of normalization to apply. Options are:
+            - "image": Normalize using global mean and std across all pixels
+            - "image_per_channel": Normalize each channel separately using its own mean and std
+            - "min_max": Scale to [0, 1] using global min and max values
+            - "min_max_per_channel": Scale each channel to [0, 1] using per-channel min and max
+        spatial_axes: Axes over which to compute statistics (default: (0, 1) for height and width).
+            Used for per-channel normalizations to determine which dimensions are spatial vs channel.
+
+    Returns:
+        Normalized image as float32 array with values clipped to [-20, 20] range to prevent
+        extreme values that could cause training instability.
+
+    Raises:
+        ValueError: If an unknown normalization method is specified.
+
+    Notes:
+        - Designed specifically for uint8 images for maximum performance
+        - Creates a 256-element lookup table mapping each possible uint8 value to its normalized value
+        - Uses OpenCV's LUT function for fast application of the transformation
+        - For per-channel normalization, creates separate LUTs for each channel
+        - Single channel images treated as "image" normalization when "image_per_channel" is specified
+    """
     dtype = img.dtype
     max_value = MAX_VALUES_BY_DTYPE[dtype]
     eps = 1e-4
@@ -604,6 +701,27 @@ def normalize_per_image_lut(img: np.ndarray, normalization: NormalizationType, s
 
 
 def normalize_per_image(img: np.ndarray, normalization: NormalizationType) -> np.ndarray:
+    """Normalize an image using the most efficient method based on image dtype and normalization type.
+
+    This is the main entry point for image normalization that automatically selects the optimal
+    implementation based on the input image data type.
+
+    Args:
+        img: Input image as a numpy array. Can be 2D (grayscale) or 3D (multi-channel).
+        normalization: Type of normalization to apply. Options are:
+            - "image": Normalize using global mean and std across all pixels
+            - "image_per_channel": Normalize each channel separately using its own mean and std
+            - "min_max": Scale to [0, 1] using global min and max values
+            - "min_max_per_channel": Scale each channel to [0, 1] using per-channel min and max
+
+    Returns:
+        Normalized image as float32 array with values clipped to [-20, 20] range.
+
+    Notes:
+        - For uint8 images (except "per_image_per_channel"), uses LUT method for maximum speed
+        - For other dtypes, uses OpenCV implementation for good performance
+        - The spatial_axes parameter defaults to (0, 1) for standard 2D images
+    """
     if img.dtype == np.uint8 and normalization != "per_image_per_channel":
         return normalize_per_image_lut(img, normalization)
 


### PR DESCRIPTION
## Summary by Sourcery

Add optional spatial_axes parameter to all per-image normalization functions

New Features:
- Allow specifying spatial axes in normalize_per_image_opencv to replace hardcoded (0,1) axes
- Allow specifying spatial axes in normalize_per_image_numpy to replace hardcoded (0,1) axes
- Allow specifying spatial axes in normalize_per_image_lut to replace hardcoded (0,1) axes