### PR TITLE
Version boosted to 0.0.25

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.11
+    rev: v0.11.13
     hooks:
       # Run the linter.
       - id: ruff
@@ -68,7 +68,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: mypy
         files: ^(albucore|benchmark)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "albucore"
-version = "0.0.24"
+version = "0.0.25"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 0.0.25 and update pre-commit development tooling

CI:
- Upgrade Ruff linter hook to v0.11.13
- Upgrade MyPy hook to v1.16.0

Chores:
- Increment package version to 0.0.25