### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -20,7 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
 
       - name: Resolve release metadata from pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "albucore"
-version = "0.1.3"
+version = "0.1.4"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
Fix release workflow Python version (3.10→3.11) so tomllib is available.

Made-with: Cursor

## Summary by Sourcery

Bump the package version and update the release workflow to use a newer Python runtime for publishing to PyPI.

Build:
- Increase project version to 0.1.4 in pyproject metadata.

CI:
- Update the PyPI release workflow to run with Python 3.11 instead of 3.10 so the standard tomllib module is available.