### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/albucore/stats.py
+++ b/albucore/stats.py
@@ -73,12 +73,17 @@ def _reduce_sum_per_channel_float32(arr: ImageFloat32, axes: tuple[int, ...], *,
 
 
 def _reduce_sum_numpy(
-    arr: ImageType,
+    arr: np.ndarray,
     axes: tuple[int, ...] | None,
     *,
     keepdims: bool,
 ) -> np.uint64 | np.float64 | np.ndarray:
-    acc = np.uint64 if arr.dtype == np.uint8 else np.float64
+    if arr.dtype == np.uint8:
+        acc: type = np.uint64
+    elif np.issubdtype(arr.dtype, np.floating):
+        acc = np.float64
+    else:
+        acc = np.int64
     return np.sum(arr, axis=axes, dtype=acc, keepdims=keepdims)
 
 
@@ -105,7 +110,8 @@ def reduce_sum(
     Alternative: ``mean`` / ``std`` / ``mean_std`` for normalised statistics.
 
     Args:
-        arr: ``uint8`` or ``float32`` array with explicit channel dimension.
+        arr: Array with explicit channel dimension. Optimised paths for ``uint8`` and ``float32``;
+            other dtypes fall back to NumPy (float → float64 accumulator, integer/bool → int64).
         axis: ``None`` / ``"global"`` → one scalar; ``"per_channel"`` → shape ``(C,)``;
             or explicit ``int`` / ``tuple[int, ...]`` (NumPy path).
         keepdims: Same semantics as :func:`numpy.sum`.
@@ -119,13 +125,11 @@ def reduce_sum(
             return _reduce_sum_global_uint8(arr, keepdims=keepdims)
         if _is_float32_image(arr):
             return _reduce_sum_global_float32(arr, keepdims=keepdims)
-        raise ValueError(f"Unsupported dtype {arr.dtype} for reduce_sum; use uint8 or float32.")
-    if axes == _per_channel_spatial_axes(arr):
+    elif axes == _per_channel_spatial_axes(arr):
         if _is_uint8_image(arr):
             return _reduce_sum_per_channel_uint8(arr, keepdims=keepdims)
         if _is_float32_image(arr):
             return _reduce_sum_per_channel_float32(arr, axes, keepdims=keepdims)
-        raise ValueError(f"Unsupported dtype {arr.dtype} for reduce_sum; use uint8 or float32.")
     return _reduce_sum_numpy(arr, axes, keepdims=keepdims)
 
 

--- a/albucore/stats.py
+++ b/albucore/stats.py
@@ -77,12 +77,13 @@ def _reduce_sum_numpy(
     axes: tuple[int, ...] | None,
     *,
     keepdims: bool,
-) -> np.uint64 | np.float64 | np.ndarray:
-    if arr.dtype == np.uint8:
+) -> np.generic | np.ndarray:
+    if np.issubdtype(arr.dtype, np.unsignedinteger):
         acc: type = np.uint64
     elif np.issubdtype(arr.dtype, np.floating):
         acc = np.float64
     else:
+        # signed integers and bool
         acc = np.int64
     return np.sum(arr, axis=axes, dtype=acc, keepdims=keepdims)
 
@@ -92,7 +93,7 @@ def reduce_sum(
     axis: AxisSpec = None,
     *,
     keepdims: bool = False,
-) -> np.uint64 | np.float64 | np.ndarray:
+) -> np.generic | np.ndarray:
     r"""Sum over image tensor axes with benchmark-driven routing.
 
     Routing:
@@ -117,7 +118,9 @@ def reduce_sum(
         keepdims: Same semantics as :func:`numpy.sum`.
 
     Returns:
-        ``numpy.uint64`` or ``numpy.float64`` scalar for a full reduction, else an array.
+        Scalar (``uint64`` / ``int64`` / ``float64``) for a full reduction, else an array.
+        The accumulator dtype follows the input: unsigned → uint64, float → float64,
+        signed int / bool → int64.
     """
     axes = _resolve_axes(arr, axis)
     if axes is None:

--- a/albucore/stats.py
+++ b/albucore/stats.py
@@ -89,7 +89,7 @@ def _reduce_sum_numpy(
 
 
 def reduce_sum(
-    arr: ImageType,
+    arr: np.ndarray,
     axis: AxisSpec = None,
     *,
     keepdims: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "albucore"
-version = "0.1.4"
+version = "0.1.5"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -351,7 +351,7 @@ def test_std_custom_eps_matches_numpy(shape: tuple[int, ...], dtype: type) -> No
 
 
 @pytest.mark.parametrize("dtype", [np.int32, np.float64])
-def test_unsupported_dtype_raises(dtype: type) -> None:
+def test_unsupported_dtype_raises_mean_std(dtype: type) -> None:
     arr = np.ones((2, 2, 1), dtype=dtype)
     with pytest.raises(ValueError, match="Unsupported dtype"):
         mean(arr)
@@ -359,10 +359,16 @@ def test_unsupported_dtype_raises(dtype: type) -> None:
         std(arr)
     with pytest.raises(ValueError, match="Unsupported dtype"):
         mean_std(arr)
-    with pytest.raises(ValueError, match="Unsupported dtype"):
-        reduce_sum(arr)
-    with pytest.raises(ValueError, match="Unsupported dtype"):
-        reduce_sum(arr, "per_channel")
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float64, np.bool_])
+def test_reduce_sum_accepts_any_dtype(dtype: type) -> None:
+    arr = np.ones((4, 4, 3), dtype=dtype)
+    result = reduce_sum(arr)
+    assert result == arr.size
+    per_ch = reduce_sum(arr, "per_channel")
+    assert per_ch.shape == (3,)
+    assert np.all(per_ch == 16)
 
 
 @pytest.mark.parametrize("c", [1, 2, 3, 4])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -350,7 +350,7 @@ def test_std_custom_eps_matches_numpy(shape: tuple[int, ...], dtype: type) -> No
     assert np.isclose(float(s), float(ref), rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.parametrize("dtype", [np.int32, np.float64])
+@pytest.mark.parametrize("dtype", [np.int32, np.float64, np.bool_, np.complex64])
 def test_unsupported_dtype_raises_mean_std(dtype: type) -> None:
     arr = np.ones((2, 2, 1), dtype=dtype)
     with pytest.raises(ValueError, match="Unsupported dtype"):
@@ -361,14 +361,42 @@ def test_unsupported_dtype_raises_mean_std(dtype: type) -> None:
         mean_std(arr)
 
 
-@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float64, np.bool_])
-def test_reduce_sum_accepts_any_dtype(dtype: type) -> None:
+@pytest.mark.parametrize(
+    ("dtype", "expected_acc_dtype"),
+    [
+        (np.int32, np.int64),
+        (np.int64, np.int64),
+        (np.uint32, np.uint64),
+        (np.uint64, np.uint64),
+        (np.float64, np.float64),
+        (np.bool_, np.int64),
+    ],
+)
+def test_reduce_sum_accumulator_dtype(dtype: type, expected_acc_dtype: type) -> None:
     arr = np.ones((4, 4, 3), dtype=dtype)
     result = reduce_sum(arr)
-    assert result == arr.size
+    assert result.dtype == expected_acc_dtype
     per_ch = reduce_sum(arr, "per_channel")
-    assert per_ch.shape == (3,)
-    assert np.all(per_ch == 16)
+    assert per_ch.dtype == expected_acc_dtype
+
+
+@pytest.mark.parametrize(
+    ("dtype", "fill", "expected_acc_dtype"),
+    [
+        # near int32 max — would overflow into int32 but must not with int64 accumulator
+        (np.int32, np.iinfo(np.int32).max, np.int64),
+        # unsigned — must not sign-extend into int64
+        (np.uint32, np.iinfo(np.uint32).max, np.uint64),
+        # float64 precision — all-same values, check no precision loss in sum
+        (np.float64, 1.0 / 3.0, np.float64),
+    ],
+)
+def test_reduce_sum_overflow_and_precision(dtype: type, fill: float, expected_acc_dtype: type) -> None:
+    arr = np.full((8, 8, 1), fill, dtype=dtype)
+    expected = np.sum(arr, dtype=expected_acc_dtype)
+    result = reduce_sum(arr)
+    assert result.dtype == expected_acc_dtype
+    assert result == expected
 
 
 @pytest.mark.parametrize("c", [1, 2, 3, 4])

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
- extend reduce_sum to accept any numpy dtype (float64, int64, bool, etc.) falling back to numpy with appropriate accumulator (float64 for floats, int64 for integers/bool) instead of raising ValueError
- update test_unsupported_dtype_raises → split into mean/std test and a new test_reduce_sum_accepts_any_dtype covering float64, int64, bool

Made-with: Cursor

## Summary by Sourcery

Allow reduce_sum to operate on a wider range of NumPy dtypes while keeping optimized paths for uint8 and float32, and bump the package version.

New Features:
- Support arbitrary NumPy dtypes in reduce_sum, falling back to NumPy with appropriate float64 or int64 accumulation.

Enhancements:
- Adjust reduce_sum behavior to no longer raise on non-uint8/float32 dtypes when using global or per-channel reductions and instead route them through the generic NumPy path.

Build:
- Bump project version from 0.1.4 to 0.1.5.

Tests:
- Split unsupported-dtype test for mean/std from reduce_sum and add coverage ensuring reduce_sum works with various integer, float, and boolean dtypes.