### PR TITLE
chore(build): migrate from setuptools to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
 
-requires = [ "setuptools>=45", "wheel" ]
+requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
@@ -48,19 +48,11 @@ contrib-headless = ["opencv-contrib-python-headless>=4.13.0.90"]
 gui = ["opencv-python>=4.13.0.90"]
 headless = ["opencv-python-headless>=4.13.0.90"]
 
-[tool.setuptools]
-packages = { find = { include = [
-  "albucore*",
-], exclude = [
-  "tests",
-  "benchmark",
-  "benchmarks",
-] } }
+[tool.hatch.build.targets.wheel]
+packages = ["albucore"]
 
-package-data = { albucore = [ "py.typed" ] }
-
-[tool.setuptools.exclude-package-data]
-"*" = [ "tests*", "benchmarks*", "benchmark*", "conda.recipe*" ]
+[tool.hatch.build.targets.sdist]
+exclude = ["tests", "benchmarks", "benchmark", "conda.recipe"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,10 @@ headless = ["opencv-python-headless>=4.13.0.90"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["albucore"]
+include = ["albucore/py.typed"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["tests", "benchmarks", "benchmark", "conda.recipe"]
+exclude = ["tests/**", "benchmarks/**", "benchmark/**", "conda.recipe/**"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
Replace setuptools/wheel build backend with hatchling. Simplifies package discovery config — hatchling automatically includes py.typed and all package data without explicit declarations.

Made-with: Cursor