### PR TITLE
perf: benchmark and route OpenCV reductions

### DIFF
--- a/albucore/arithmetic.py
+++ b/albucore/arithmetic.py
@@ -21,7 +21,7 @@ from albucore.utils import (
     convert_value,
     get_num_channels,
 )
-from albucore.weighted import add_array_numkong, add_weighted_numkong
+from albucore.weighted import add_array_numkong, add_weighted_numkong, multiply_add_numkong
 
 np_operations = {"multiply": np.multiply, "add": np.add, "power": np.power}
 
@@ -569,6 +569,15 @@ def _is_all_zero_param(x: float | np.ndarray) -> bool:
     return float(x) == 0.0
 
 
+def _use_numkong_scalar_multiply_add(img: ImageType, factor: ValueType, value: ValueType) -> bool:
+    return (
+        _is_float32_image(img)
+        and isinstance(factor, (float, int))
+        and isinstance(value, (float, int))
+        and img.size >= 1_000_000
+    )
+
+
 def multiply_add_numpy(img: ImageType, factor: ValueType, value: ValueType) -> ImageFloat32:
     img_f = img.astype(np.float32, copy=False)
 
@@ -682,5 +691,8 @@ def multiply_add(img: ImageType, factor: ValueType, value: ValueType, inplace: b
 
     if _is_uint8_image(img):
         return multiply_add_lut(img, factor, value, inplace)
+
+    if _use_numkong_scalar_multiply_add(img, factor, value):
+        return multiply_add_numkong(img, float(factor), float(value))
 
     return multiply_add_numpy(img, factor, value)

--- a/albucore/normalize.py
+++ b/albucore/normalize.py
@@ -54,13 +54,22 @@ def _normalize_mean_std_opencv(img: ImageType, mean: float | np.ndarray, std: fl
     return np.clip(normalized_img, -20, 20, out=normalized_img)
 
 
+def _min_max_per_channel(img: ImageType) -> tuple[np.ndarray, np.ndarray]:
+    axes = tuple(range(img.ndim - 1))
+    if img.shape[-1] == 1:
+        return img.min(axis=axes), img.max(axis=axes)
+
+    flat = np.ascontiguousarray(img).reshape(-1, img.shape[-1])
+    dtype = cv2.CV_32F if img.dtype == np.float32 else -1
+    img_min = cv2.reduce(flat, 0, cv2.REDUCE_MIN, dtype=dtype).reshape(-1)
+    img_max = cv2.reduce(flat, 0, cv2.REDUCE_MAX, dtype=dtype).reshape(-1)
+    return img_min, img_max
+
+
 def _normalize_min_max_per_channel_opencv(img: ImageType) -> ImageFloat32:
     """Apply per-channel min-max normalization."""
     eps = 1e-4
-    axes = tuple(range(img.ndim - 1))  # All axes except channel
-
-    img_min = img.min(axis=axes)
-    img_max = img.max(axis=axes)
+    img_min, img_max = _min_max_per_channel(img)
 
     if img.shape[-1] > MAX_OPENCV_WORKING_CHANNELS:
         img_min = np.full_like(img, img_min)

--- a/albucore/stats.py
+++ b/albucore/stats.py
@@ -39,6 +39,19 @@ def _per_channel_spatial_axes(arr: np.ndarray) -> tuple[int, ...]:
     return tuple(range(arr.ndim - 1))
 
 
+def _cv2_reduce_sum_per_channel(arr: np.ndarray) -> np.ndarray:
+    flat = np.ascontiguousarray(arr).reshape(-1, arr.shape[-1])
+    result = np.asarray(cv2.reduce(flat, 0, cv2.REDUCE_SUM, dtype=cv2.CV_64F).reshape(-1))
+    if _is_uint8_image(arr):
+        return np.asarray(result, dtype=np.uint64)
+    return np.asarray(result, dtype=np.float64)
+
+
+def _cv2_reduce_mean_per_channel(arr: np.ndarray) -> np.ndarray:
+    flat = np.ascontiguousarray(arr).reshape(-1, arr.shape[-1])
+    return np.asarray(cv2.reduce(flat, 0, cv2.REDUCE_AVG, dtype=cv2.CV_64F).reshape(-1), dtype=np.float64)
+
+
 def _reduce_sum_global_uint8(arr: ImageUInt8, *, keepdims: bool) -> np.uint64 | np.ndarray:
     out = np.uint64(int(nk.sum(arr)))
     if keepdims:
@@ -55,15 +68,26 @@ def _reduce_sum_global_float32(arr: ImageFloat32, *, keepdims: bool) -> np.float
 
 def _reduce_sum_per_channel_uint8(arr: ImageUInt8, *, keepdims: bool) -> np.ndarray:
     axes = _per_channel_spatial_axes(arr)
-    result = np.asarray(nk.sum(arr, axis=axes), dtype=np.uint64)
+    c = arr.shape[-1]
+    n_spatial = arr.size // c
+    if c > MAX_OPENCV_WORKING_CHANNELS and n_spatial >= 65_536:
+        result = _cv2_reduce_sum_per_channel(arr)
+    else:
+        result = np.asarray(nk.sum(arr, axis=axes), dtype=np.uint64)
     if keepdims:
-        return result.reshape((1,) * (arr.ndim - 1) + (arr.shape[-1],))
+        return result.reshape((1,) * (arr.ndim - 1) + (c,))
     return result
 
 
 def _reduce_sum_per_channel_float32(arr: ImageFloat32, axes: tuple[int, ...], *, keepdims: bool) -> np.ndarray:
     """Per-channel sum for float32: nk.sum for ndim ≤ 4 and 1 < C ≤ 4 (4x faster than numpy), numpy otherwise."""
     c = arr.shape[-1]
+    n_spatial = arr.size // c
+    if c > MAX_OPENCV_WORKING_CHANNELS and n_spatial >= 16_384:
+        result = _cv2_reduce_sum_per_channel(arr)
+        if keepdims:
+            return result.reshape((1,) * (arr.ndim - 1) + (c,))
+        return result
     if arr.ndim <= 4 and 1 < c <= MAX_OPENCV_WORKING_CHANNELS:
         result = np.asarray(nk.sum(arr, axis=axes), dtype=np.float64)
         if keepdims:
@@ -221,9 +245,13 @@ def _mean_std_per_channel(
 def _mean_per_channel_uint8(arr: ImageUInt8, axes: tuple[int, ...], *, keepdims: bool) -> np.ndarray:
     """Per-channel mean for uint8 via nk.sum — fastest for all shapes and channel counts."""
     n_spatial = arr.size // arr.shape[-1]
-    result = np.asarray(nk.sum(arr, axis=axes), dtype=np.float64) / n_spatial
+    c = arr.shape[-1]
+    if c > MAX_OPENCV_WORKING_CHANNELS and n_spatial >= 65_536:
+        result = _cv2_reduce_mean_per_channel(arr)
+    else:
+        result = np.asarray(nk.sum(arr, axis=axes), dtype=np.float64) / n_spatial
     if keepdims:
-        return result.reshape((1,) * (arr.ndim - 1) + (arr.shape[-1],))
+        return result.reshape((1,) * (arr.ndim - 1) + (c,))
     return result
 
 
@@ -245,6 +273,11 @@ def _mean_per_channel(
     if arr.ndim == 4 and not keepdims and axes == spatial_axes and 1 < c <= MAX_OPENCV_WORKING_CHANNELS:
         n_spatial = arr.size // c
         return np.asarray(nk.sum(arr, axis=axes), dtype=np.float64) / n_spatial
+    if c > MAX_OPENCV_WORKING_CHANNELS and axes == spatial_axes and arr.size // c >= 16_384:
+        result = _cv2_reduce_mean_per_channel(arr)
+        if keepdims:
+            return result.reshape((1,) * (arr.ndim - 1) + (c,))
+        return result
     return np.asarray(arr.mean(axis=axes, dtype=np.float64, keepdims=keepdims), dtype=np.float64)
 
 

--- a/albucore/weighted.py
+++ b/albucore/weighted.py
@@ -48,3 +48,14 @@ def add_constant_numkong(img: ImageType, value: float) -> ImageType:
     if out is None:
         raise RuntimeError("nk.scale returned None")
     return cast("ImageType", np.asarray(out, dtype=original_dtype).reshape(original_shape))
+
+
+def multiply_add_numkong(img: ImageType, factor: float, value: float) -> ImageType:
+    """Scalar affine transform via ``nk.scale`` (alpha*x + beta)."""
+    original_shape = img.shape
+    original_dtype = img.dtype
+    flat = np.ascontiguousarray(img).reshape(-1)
+    out = nk.scale(flat, alpha=float(factor), beta=float(value))
+    if out is None:
+        raise RuntimeError("nk.scale returned None")
+    return cast("ImageType", np.asarray(out, dtype=original_dtype).reshape(original_shape))

--- a/benchmarks/benchmark_minmax_ravel.py
+++ b/benchmarks/benchmark_minmax_ravel.py
@@ -14,10 +14,19 @@ from __future__ import annotations
 import argparse
 import platform
 
+import cv2
 import numkong as nk
 import numpy as np
 
 from timing import median_ms
+
+
+def _cv2_reduce_minmax_per_channel(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    flat = np.ascontiguousarray(arr).reshape(-1, arr.shape[-1])
+    dtype = cv2.CV_32F if arr.dtype == np.float32 else -1
+    mn = cv2.reduce(flat, 0, cv2.REDUCE_MIN, dtype=dtype).reshape(-1)
+    mx = cv2.reduce(flat, 0, cv2.REDUCE_MAX, dtype=dtype).reshape(-1)
+    return mn, mx
 
 
 def main() -> None:
@@ -34,8 +43,20 @@ def main() -> None:
         (512, 512, 3),  # medium
         (1024, 1024, 1),  # large grayscale
     ]
+    per_channel_shapes: list[tuple[int, ...]] = [
+        (128, 128, 1),
+        (128, 128, 3),
+        (128, 128, 9),
+        (512, 512, 3),
+        (512, 512, 9),
+        (1024, 1024, 3),
+        (1024, 1024, 9),
+        (4, 256, 256, 3),
+        (4, 256, 256, 9),
+    ]
 
     rows: list[tuple[str, str, int, float, float, str, float]] = []
+    pc_rows: list[tuple[str, str, float, float, str, float]] = []
 
     for dtype, dname in [(np.float32, "float32"), (np.uint8, "uint8")]:
         for h, w, c in shapes:
@@ -58,6 +79,25 @@ def main() -> None:
             faster = "NumPy" if t_np <= t_nk else "NumKong"
             ratio = max(t_nk, t_np) / max(min(t_nk, t_np), 1e-12)
             rows.append((dname, f"{h}×{w}×{c}", flat.size, t_nk, t_np, faster, ratio))
+
+        for shape in per_channel_shapes:
+            if dtype == np.uint8:
+                arr = rng.integers(0, 256, size=shape, dtype=np.uint8)
+            else:
+                arr = rng.random(shape, dtype=np.float32)
+            axes = tuple(range(arr.ndim - 1))
+
+            def np_pc_mm() -> tuple[np.ndarray, np.ndarray]:
+                return arr.min(axis=axes), arr.max(axis=axes)
+
+            def cv_pc_mm() -> tuple[np.ndarray, np.ndarray]:
+                return _cv2_reduce_minmax_per_channel(arr)
+
+            t_np = median_ms(np_pc_mm, args.repeats, args.warmup)
+            t_cv = median_ms(cv_pc_mm, args.repeats, args.warmup)
+            faster = "NumPy" if t_np <= t_cv else "OpenCV"
+            ratio = max(t_np, t_cv) / max(min(t_np, t_cv), 1e-12)
+            pc_rows.append((dname, "×".join(str(x) for x in shape), t_np, t_cv, faster, ratio))
 
     print()
     print("### Benchmark: `Tensor.minmax()` vs `np.min` + `np.max` (image-shaped data)")
@@ -109,6 +149,15 @@ def main() -> None:
     print("than `Tensor.minmax()` on all tested sizes/dtypes. So for axis-wise `minmax` APIs, ")
     print("downstream libs may still prefer NumPy (or batched native reductions) unless NumKong wins on ")
     print("their exact strided/axis case.")
+    print()
+    print("### Benchmark: per-channel min+max, NumPy axis reduce vs `cv2.reduce`")
+    print()
+    print("**Setup:** Channel-last arrays, per-channel min/max over all axes except the last.")
+    print()
+    print("| dtype | shape | NumPy min+max (ms) | OpenCV `reduce` min+max (ms) | faster | ratio |")
+    print("|-------|-------|-------------------:|-----------------------------:|--------|------:|")
+    for dname, sh, t_np, t_cv, faster, ratio in pc_rows:
+        print(f"| {dname} | {sh} | {t_np:.4f} | {t_cv:.4f} | {faster} | {ratio:.2f}× |")
     print()
     print(
         f"_Environment: **{platform.system()}** `{platform.machine()}`, "

--- a/benchmarks/benchmark_multiply_add_numkong.py
+++ b/benchmarks/benchmark_multiply_add_numkong.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 
+import cv2
 import numkong as nk
 import numpy as np
 
@@ -18,6 +19,8 @@ from albucore.functions import (
     add_array_numkong,
     add_constant,
     add_vector,
+    multiply_add,
+    multiply_add_numpy,
     multiply_by_array,
     multiply_by_constant,
     multiply_by_vector,
@@ -75,6 +78,11 @@ def nk_channelwise_scale(img: np.ndarray, per_ch: np.ndarray, *, alpha_per_ch: b
     return clip(out, np.uint8)
 
 
+def cv2_addweighted_scalar_affine(img: np.ndarray, *, alpha: float, beta: float) -> np.ndarray:
+    raw = cv2.addWeighted(img, alpha, img, 0.0, beta, dtype=cv2.CV_32F)
+    return clip(raw, np.float32)
+
+
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--repeats", type=int, default=9)
@@ -113,6 +121,27 @@ def main() -> None:
                 best = min(opts, key=lambda x: x[1])[0]
                 dname = "uint8" if dtype == np.uint8 else "float32"
                 print(f"| {dname} | {h}×{w} | {c} | {t_prod:.4f} | {t_nk:.4f} | {t_nk_ip:.4f} | {best} |")
+    print()
+
+    # --- scalar multiply-add ---
+    print("## `multiply_add` — scalar affine `factor * img + value`")
+    print()
+    print("| dtype | H×W | C | prod | NumPy | NK scale (alloc) | OpenCV `addWeighted` | fastest |")
+    print("|-------|-----|---|-----:|------:|-----------------:|---------------------:|---------|")
+    for h, w in sizes:
+        for c in channels:
+            img = rng.random((h, w, c), dtype=np.float32)
+            t_prod = median_ms(lambda: multiply_add(img, s_mul, s_add), args.repeats, args.warmup)
+            t_np = median_ms(lambda: clip(multiply_add_numpy(img, s_mul, s_add), np.float32), args.repeats, args.warmup)
+            t_nk = median_ms(lambda: nk_scale_flat(img, alpha=s_mul, beta=s_add), args.repeats, args.warmup)
+            t_cv = median_ms(
+                lambda: cv2_addweighted_scalar_affine(img, alpha=s_mul, beta=s_add),
+                args.repeats,
+                args.warmup,
+            )
+            opts = [("prod", t_prod), ("numpy", t_np), ("NK_alloc", t_nk), ("OpenCV_addWeighted", t_cv)]
+            best = min(opts, key=lambda x: x[1])[0]
+            print(f"| float32 | {h}×{w} | {c} | {t_prod:.4f} | {t_np:.4f} | {t_nk:.4f} | {t_cv:.4f} | {best} |")
     print()
 
     # --- scalar add ---

--- a/benchmarks/benchmark_reduce_sum.py
+++ b/benchmarks/benchmark_reduce_sum.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 
+import cv2
 import numkong as nk
 import numpy as np
 from timing import median_ms
@@ -36,6 +37,16 @@ def _nk_sum_global(arr: np.ndarray) -> float:
 
 def _nk_sum_per_channel(arr: np.ndarray) -> np.ndarray:
     return np.asarray(nk.sum(arr, axis=tuple(range(arr.ndim - 1))))
+
+
+def _cv2_reduce_sum_per_channel(arr: np.ndarray) -> np.ndarray:
+    flat = np.ascontiguousarray(arr).reshape(-1, arr.shape[-1])
+    return cv2.reduce(flat, 0, cv2.REDUCE_SUM, dtype=cv2.CV_64F).reshape(-1)
+
+
+def _cv2_reduce_mean_per_channel(arr: np.ndarray) -> np.ndarray:
+    flat = np.ascontiguousarray(arr).reshape(-1, arr.shape[-1])
+    return cv2.reduce(flat, 0, cv2.REDUCE_AVG, dtype=cv2.CV_64F).reshape(-1)
 
 
 def _nk_mean_via_sum(arr: np.ndarray) -> float:
@@ -72,6 +83,9 @@ def _nk_std_per_channel(arr: np.ndarray) -> np.ndarray:
 HDR3 = "| dtype | shape | prod ms | nk_new ms | numpy ms | fastest |"
 SEP3 = "|-------|-------|--------:|----------:|---------:|---------|"
 
+HDR_CAND = "| dtype | shape | prod ms | cv2.reduce ms | nk_new ms | numpy ms | fastest |"
+SEP_CAND = "|-------|-------|--------:|--------------:|----------:|---------:|---------|"
+
 HDR4 = "| dtype | shape | prod ms | nk_sum/n ms | nk_moments/n ms | numpy ms | fastest |"
 SEP4 = "|-------|-------|--------:|------------:|----------------:|---------:|---------|"
 
@@ -87,6 +101,23 @@ def _row3(
     fastest = min(times, key=times.__getitem__)
     shape_str = "×".join(str(x) for x in shape)
     return f"| {dtype_name} | {shape_str} | {t_prod:.4f} | {t_nk:.4f} | {t_np:.4f} | **{fastest}** |"
+
+
+def _row_candidates(
+    dtype_name: str,
+    shape: tuple[int, ...],
+    t_prod: float,
+    t_cv2: float,
+    t_nk: float,
+    t_np: float,
+) -> str:
+    times = {"prod": t_prod, "cv2.reduce": t_cv2, "nk_new": t_nk, "numpy": t_np}
+    fastest = min(times, key=times.__getitem__)
+    shape_str = "×".join(str(x) for x in shape)
+    return (
+        f"| {dtype_name} | {shape_str} | {t_prod:.4f} | {t_cv2:.4f} | "
+        f"{t_nk:.4f} | {t_np:.4f} | **{fastest}** |"
+    )
 
 
 def _row4(
@@ -115,6 +146,14 @@ def _section4(title: str, rows: list[str]) -> None:
     print(f"\n### {title}\n")
     print(HDR4)
     print(SEP4)
+    for r in rows:
+        print(r)
+
+
+def _section_candidates(title: str, rows: list[str]) -> None:
+    print(f"\n### {title}\n")
+    print(HDR_CAND)
+    print(SEP_CAND)
     for r in rows:
         print(r)
 
@@ -169,9 +208,10 @@ def main() -> None:
 
             # sum per-channel
             t_prod = median_ms(lambda a=arr: reduce_sum(a, "per_channel"), reps, wu)
+            t_cv2 = median_ms(lambda a=arr: _cv2_reduce_sum_per_channel(a), reps, wu)
             t_nk   = median_ms(lambda a=arr: _nk_sum_per_channel(a), reps, wu)
             t_np   = median_ms(lambda a=arr, ax=axes, ac=acc: np.sum(a, axis=ax, dtype=ac), reps, wu)
-            sum_pc_rows.append(_row3(dname, shape, t_prod, t_nk, t_np))
+            sum_pc_rows.append(_row_candidates(dname, shape, t_prod, t_cv2, t_nk, t_np))
 
             # mean global — prod vs nk.sum/n vs nk.moments/n vs numpy
             t_prod    = median_ms(lambda a=arr: mean(a, "global"), reps, wu)
@@ -182,9 +222,10 @@ def main() -> None:
 
             # mean per-channel — prod vs nk.sum(spatial)/n vs numpy
             t_prod = median_ms(lambda a=arr: mean(a, "per_channel"), reps, wu)
+            t_cv2 = median_ms(lambda a=arr: _cv2_reduce_mean_per_channel(a), reps, wu)
             t_nk   = median_ms(lambda a=arr: _nk_mean_per_channel(a), reps, wu)
             t_np   = median_ms(lambda a=arr, ax=axes: np.mean(a, axis=ax, dtype=np.float64), reps, wu)
-            mean_pc_rows.append(_row3(dname, shape, t_prod, t_nk, t_np))
+            mean_pc_rows.append(_row_candidates(dname, shape, t_prod, t_cv2, t_nk, t_np))
 
             # std per-channel — prod vs nk two-pass vs numpy
             t_prod = median_ms(lambda a=arr: std(a, "per_channel"), reps, wu)
@@ -194,9 +235,9 @@ def main() -> None:
 
         print(f"\n## {dname}")
         _section3("sum global", sum_global_rows)
-        _section3("sum per-channel", sum_pc_rows)
+        _section_candidates("sum per-channel", sum_pc_rows)
         _section4("mean global  (prod=moments/n · nk_sum=sum/n · nk_moments=moments/n)", mean_global_rows)
-        _section3("mean per-channel  (nk_new = nk.sum(spatial)/n)", mean_pc_rows)
+        _section_candidates("mean per-channel  (nk_new = nk.sum(spatial)/n)", mean_pc_rows)
         _section3("std per-channel  (nk_new = sqrt(sum2/n - (sum/n)^2) + eps)", std_pc_rows)
 
 


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Route certain high-volume per-channel reductions and scalar affine operations through OpenCV and NumKong where beneficial, and extend benchmarks to compare these implementations against NumPy and existing production paths.

New Features:
- Add per-channel min/max benchmarking comparing NumPy axis reductions to OpenCV cv2.reduce across various channel counts and shapes.
- Introduce benchmarks for scalar multiply-add comparing production implementation, NumPy, NumKong-based scaling, and OpenCV addWeighted.

Enhancements:
- Use OpenCV cv2.reduce-based implementations for per-channel sum and mean in stats for large, high-channel-count images when they outperform existing NumKong/NumPy paths.
- Refine per-channel mean and sum routing logic to choose between NumKong, OpenCV, and NumPy based on dimensionality, channel count, and spatial size.
- Optimize per-channel min-max normalization by using OpenCV reductions for multi-channel images.
- Route scalar float32 multiply-add on large images through a NumKong-backed implementation for improved performance.