### PR TITLE
fix: install headless extra for release validation

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -68,7 +68,7 @@ jobs:
         run: uv build
 
       - name: Install release validation dependencies
-        run: uv sync --extra headless --group dev
+        run: uv sync --frozen --extra headless --group dev
 
       - name: Check public router contracts
         run: uv run python tools/check_router_contracts.py

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build distributions
         run: uv build
 
+      - name: Install release validation dependencies
+        run: uv sync --extra headless --group dev
+
       - name: Check public router contracts
         run: uv run python tools/check_router_contracts.py
 

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -5,13 +5,13 @@ Golden vectors freeze representative Albucore public-router behavior on small de
 Regenerate explicitly:
 
 ```bash
-uv run python tools/generate_golden_vectors.py
+uv run --extra headless python tools/generate_golden_vectors.py
 ```
 
 Verify:
 
 ```bash
-uv run python tools/verify_golden_vectors.py
+uv run --extra headless python tools/verify_golden_vectors.py
 ```
 
 Tests never regenerate goldens automatically.

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -97,6 +97,7 @@ def _check_release_workflow(errors: list[str]) -> None:
         "release regression checker": "tools/check_benchmark_regressions.py",
         "release regression mode": "--mode release",
         "regression report artifact": "dist/router-release-regressions.md",
+        "release validation headless extra": "uv sync --extra headless --group dev",
         "project-free runtime dependency export": "uv export --frozen --no-dev --no-emit-project",
     }
     errors.extend(

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -97,7 +97,7 @@ def _check_release_workflow(errors: list[str]) -> None:
         "release regression checker": "tools/check_benchmark_regressions.py",
         "release regression mode": "--mode release",
         "regression report artifact": "dist/router-release-regressions.md",
-        "release validation headless extra": "uv sync --extra headless --group dev",
+        "release validation headless extra": "uv sync --frozen --extra headless --group dev",
         "project-free runtime dependency export": "uv export --frozen --no-dev --no-emit-project",
     }
     errors.extend(


### PR DESCRIPTION
## Summary by Sourcery

Ensure release validation and golden vector tooling install and run with the headless extra in CI and documented workflows.

Enhancements:
- Extend CI matrix release workflow checks to assert installation of headless extra dev dependencies as part of release validation.

CI:
- Add a release validation step in the PyPI upload workflow to install headless extra dev dependencies before running router contract checks.

Documentation:
- Update golden vector regeneration and verification instructions to use the headless extra when running tools.