### PR TITLE
Codex/bump version 0.2.1

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -68,7 +68,7 @@ jobs:
         run: uv build
 
       - name: Install release validation dependencies
-        run: uv sync --extra headless --group dev
+        run: uv sync --frozen --extra headless --group dev
 
       - name: Check public router contracts
         run: uv run python tools/check_router_contracts.py

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -111,7 +111,6 @@ jobs:
       - name: Resolve previous published PyPI version
         run: |
           python tools/resolve_previous_pypi_release.py \
-            --project albucore \
             --current-version "${PACKAGE_VERSION}" \
             --github-env "${GITHUB_ENV}"
 

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build distributions
         run: uv build
 
+      - name: Install release validation dependencies
+        run: uv sync --extra headless --group dev
+
       - name: Check public router contracts
         run: uv run python tools/check_router_contracts.py
 

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -108,44 +108,12 @@ jobs:
       - name: Verify uv.lock is up-to-date
         run: uv lock --check
 
-      - name: Resolve previous release version
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          REPOSITORY: ${{ github.repository }}
+      - name: Resolve previous published PyPI version
         run: |
-          python - <<'PY' >> "$GITHUB_ENV"
-          import json
-          import os
-          import urllib.request
-
-          request = urllib.request.Request(
-              f"https://api.github.com/repos/{os.environ['REPOSITORY']}/releases?per_page=100",
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
-          )
-          with urllib.request.urlopen(request, timeout=30) as response:
-              releases = json.load(response)
-
-          current_tag = os.environ["RELEASE_TAG"]
-          previous = next(
-              (
-                  release
-                  for release in releases
-                  if not release.get("draft") and release.get("tag_name") != current_tag
-              ),
-              None,
-          )
-          if previous is None:
-              raise SystemExit(f"No previous GitHub Release found before {current_tag}.")
-
-          previous_tag = previous["tag_name"]
-          print(f"PREVIOUS_RELEASE_TAG={previous_tag}")
-          print(f"PREVIOUS_RELEASE_VERSION={previous_tag.removeprefix('v')}")
-          PY
+          python tools/resolve_previous_pypi_release.py \
+            --project albucore \
+            --current-version "${PACKAGE_VERSION}" \
+            --github-env "${GITHUB_ENV}"
 
       - name: Run current release router benchmark
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.0"
+version = "0.2.1"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -5,13 +5,13 @@ Golden vectors freeze representative Albucore public-router behavior on small de
 Regenerate explicitly:
 
 ```bash
-uv run python tools/generate_golden_vectors.py
+uv run --extra headless python tools/generate_golden_vectors.py
 ```
 
 Verify:
 
 ```bash
-uv run python tools/verify_golden_vectors.py
+uv run --extra headless python tools/verify_golden_vectors.py
 ```
 
 Tests never regenerate goldens automatically.

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -4,6 +4,7 @@ import json
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from tools import (
     check_benchmark_regressions,
@@ -133,6 +134,11 @@ def test_previous_pypi_release_cli_writes_github_env(tmp_path, monkeypatch, caps
     assert resolve_previous_pypi_release.main() == 0
     assert env_path.read_text() == "PREVIOUS_RELEASE_VERSION=0.1.6\n"
     assert "PREVIOUS_RELEASE_VERSION=0.1.6" in capsys.readouterr().out
+
+
+def test_pypi_release_payload_must_be_json_object() -> None:
+    with pytest.raises(TypeError, match="not a JSON object"):
+        resolve_previous_pypi_release.pypi_releases_from_payload("albucore", [])
 
 
 def test_golden_vector_verify_checks_computed_dtype(tmp_path, monkeypatch) -> None:

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -5,7 +5,14 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from tools import ci_matrix, check_benchmark_regressions, check_router_contracts, summarize_benchmarks, verify_golden_vectors
+from tools import (
+    check_benchmark_regressions,
+    check_router_contracts,
+    ci_matrix,
+    resolve_previous_pypi_release,
+    summarize_benchmarks,
+    verify_golden_vectors,
+)
 from tools.golden_vectors import array_metadata
 from tests.router_contracts import ROUTER_CONTRACTS
 
@@ -89,6 +96,43 @@ def test_benchmark_summary_reads_router_json(tmp_path, monkeypatch, capsys) -> N
     captured = capsys.readouterr()
     assert "Benchmark Summary" in captured.out
     assert "`normalize`" in captured.out
+
+
+def test_previous_pypi_release_skips_unpublished_release() -> None:
+    releases = {
+        "0.1.5": [{"filename": "albucore-0.1.5.tar.gz", "yanked": False}],
+        "0.1.6": [{"filename": "albucore-0.1.6.tar.gz", "yanked": False}],
+        "0.2.0": [],
+        "0.2.1": [{"filename": "albucore-0.2.1.tar.gz", "yanked": False}],
+    }
+
+    previous = resolve_previous_pypi_release.previous_published_version("0.2.1", releases)
+
+    assert previous == "0.1.6"
+
+
+def test_previous_pypi_release_cli_writes_github_env(tmp_path, monkeypatch, capsys) -> None:
+    env_path = tmp_path / "github-env"
+    releases = {
+        "0.1.6": [{"filename": "albucore-0.1.6.tar.gz", "yanked": False}],
+        "0.2.0": [],
+    }
+
+    monkeypatch.setattr(resolve_previous_pypi_release, "fetch_pypi_releases", lambda project: releases)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "resolve_previous_pypi_release.py",
+            "--current-version",
+            "0.2.1",
+            "--github-env",
+            str(env_path),
+        ],
+    )
+
+    assert resolve_previous_pypi_release.main() == 0
+    assert env_path.read_text() == "PREVIOUS_RELEASE_VERSION=0.1.6\n"
+    assert "PREVIOUS_RELEASE_VERSION=0.1.6" in capsys.readouterr().out
 
 
 def test_golden_vector_verify_checks_computed_dtype(tmp_path, monkeypatch) -> None:

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -92,7 +92,8 @@ def _check_support_policy(errors: list[str], versions: set[str]) -> None:
 def _check_release_workflow(errors: list[str]) -> None:
     text = RELEASE_WORKFLOW.read_text()
     required_fragments = {
-        "previous release resolver": "PREVIOUS_RELEASE_VERSION",
+        "previous PyPI release resolver": "tools/resolve_previous_pypi_release.py",
+        "previous release benchmark version": "PREVIOUS_RELEASE_VERSION",
         "baseline benchmark artifact": "dist/router-baseline.json",
         "release regression checker": "tools/check_benchmark_regressions.py",
         "release regression mode": "--mode release",

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -97,6 +97,7 @@ def _check_release_workflow(errors: list[str]) -> None:
         "release regression checker": "tools/check_benchmark_regressions.py",
         "release regression mode": "--mode release",
         "regression report artifact": "dist/router-release-regressions.md",
+        "release validation headless extra": "uv sync --extra headless --group dev",
         "project-free runtime dependency export": "uv export --frozen --no-dev --no-emit-project",
     }
     errors.extend(

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -97,7 +97,7 @@ def _check_release_workflow(errors: list[str]) -> None:
         "release regression checker": "tools/check_benchmark_regressions.py",
         "release regression mode": "--mode release",
         "regression report artifact": "dist/router-release-regressions.md",
-        "release validation headless extra": "uv sync --extra headless --group dev",
+        "release validation headless extra": "uv sync --frozen --extra headless --group dev",
         "project-free runtime dependency export": "uv export --frozen --no-dev --no-emit-project",
     }
     errors.extend(

--- a/tools/resolve_previous_pypi_release.py
+++ b/tools/resolve_previous_pypi_release.py
@@ -1,0 +1,95 @@
+"""Resolve the previous published PyPI release for release benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PROJECT_NAME = "albucore"
+PYPI_JSON_URL = "https://pypi.org/pypi/{project}/json"
+_FINAL_RELEASE_RE = re.compile(r"^\d+(?:\.\d+)*$")
+
+
+def final_release_key(version: str) -> tuple[int, ...] | None:
+    """Return a sortable key for final numeric releases, ignoring pre/dev/local versions."""
+    normalized = version.removeprefix("v")
+    if _FINAL_RELEASE_RE.fullmatch(normalized) is None:
+        return None
+    return tuple(int(part) for part in normalized.split("."))
+
+
+def has_installable_files(files: object) -> bool:
+    """Return True when a PyPI release has at least one non-yanked file."""
+    if not isinstance(files, list):
+        return False
+    return any(isinstance(file, dict) and not file.get("yanked", False) for file in files)
+
+
+def previous_published_version(current_version: str, releases: dict[str, Any]) -> str:
+    """Return the latest published final release lower than current_version."""
+    current_key = final_release_key(current_version)
+    if current_key is None:
+        msg = f"Current version must be a final numeric release, got {current_version!r}."
+        raise ValueError(msg)
+
+    candidates = [
+        (key, version)
+        for version, files in releases.items()
+        if (key := final_release_key(version)) is not None and key < current_key and has_installable_files(files)
+    ]
+    if not candidates:
+        msg = f"No published PyPI release found before {current_version}."
+        raise ValueError(msg)
+
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def fetch_pypi_releases(project: str, timeout: float = 30.0) -> dict[str, Any]:
+    """Fetch project releases from PyPI JSON metadata."""
+    url = PYPI_JSON_URL.format(project=project)
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        payload = json.load(response)
+
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        msg = f"PyPI response for {project!r} does not contain a releases table."
+        raise TypeError(msg)
+    return releases
+
+
+def write_github_env(path: Path, previous_version: str) -> None:
+    """Append the resolved version to a GitHub Actions environment file."""
+    with path.open("a") as file:
+        file.write(f"PREVIOUS_RELEASE_VERSION={previous_version}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=PROJECT_NAME)
+    parser.add_argument("--current-version", required=True)
+    parser.add_argument("--github-env", type=Path)
+    args = parser.parse_args()
+
+    try:
+        previous_version = previous_published_version(
+            args.current_version,
+            fetch_pypi_releases(args.project),
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        sys.stderr.write(f"Failed to resolve previous PyPI release: {exc}\n")
+        return 1
+
+    if args.github_env is not None:
+        write_github_env(args.github_env, previous_version)
+
+    sys.stdout.write(f"PREVIOUS_RELEASE_VERSION={previous_version}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/resolve_previous_pypi_release.py
+++ b/tools/resolve_previous_pypi_release.py
@@ -55,6 +55,15 @@ def fetch_pypi_releases(project: str, timeout: float = 30.0) -> dict[str, Any]:
     with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
         payload = json.load(response)
 
+    return pypi_releases_from_payload(project, payload)
+
+
+def pypi_releases_from_payload(project: str, payload: object) -> dict[str, Any]:
+    """Extract the releases table from a PyPI JSON payload."""
+    if not isinstance(payload, dict):
+        msg = f"PyPI response for {project!r} is not a JSON object."
+        raise TypeError(msg)
+
     releases = payload.get("releases")
     if not isinstance(releases, dict):
         msg = f"PyPI response for {project!r} does not contain a releases table."

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary by Sourcery

Bump the albucore package to version 0.2.1 and switch release regression benchmarking to resolve the previous published PyPI release instead of relying on GitHub releases.

New Features:
- Add a resolve_previous_pypi_release utility script to determine the latest published PyPI version prior to a given release and emit it for GitHub Actions.

Enhancements:
- Update the release CI workflow to install headless/dev dependencies, use the new PyPI-based previous release resolver, and enforce this configuration via the CI matrix check.
- Adjust golden vector documentation and commands to run under the headless extra environment.

Build:
- Update pyproject to set the albucore project version to 0.2.1 and refresh the uv.lock dependency lockfile.

Tests:
- Add tests covering the previous PyPI release resolver logic and its CLI interaction with GitHub Action environment files.