### PR TITLE
Harden release validation edge cases

### DIFF
--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -126,8 +126,8 @@ def test_benchmark_regression_check_accepts_explicit_release_regression(tmp_path
                         "layout": "HWC",
                         "shape": [128, 160, 3],
                         "dtype": "float32",
-                        "reason": "intentional correctness fix",
-                        "approved_by": "maintainer",
+                        "reason": "intentional | correctness fix",
+                        "approved_by": "maintainer | release owner",
                     },
                 ],
             },
@@ -154,8 +154,8 @@ def test_benchmark_regression_check_accepts_explicit_release_regression(tmp_path
     assert check_benchmark_regressions.main() == 0
     report_text = report.read_text()
     assert "`accepted`" in report_text
-    assert "intentional correctness fix" in report_text
-    assert "maintainer" in report_text
+    assert r"`intentional \| correctness fix`" in report_text
+    assert r"`maintainer \| release owner`" in report_text
 
 
 def test_benchmark_regression_check_rejects_undocumented_accepted_regression(tmp_path, monkeypatch) -> None:
@@ -195,6 +195,56 @@ def test_benchmark_regression_check_rejects_undocumented_accepted_regression(tmp
     )
 
     with pytest.raises(TypeError, match="reason"):
+        check_benchmark_regressions.main()
+
+
+def test_benchmark_regression_check_rejects_duplicate_accepted_regression_key(tmp_path, monkeypatch) -> None:
+    baseline = tmp_path / "baseline.json"
+    current = tmp_path / "current.json"
+    accepted = tmp_path / "accepted.json"
+    baseline.write_text(json.dumps(_router_json(1.0)))
+    current.write_text(json.dumps(_router_json(1.2)))
+    accepted.write_text(
+        json.dumps(
+            {
+                "regressions": [
+                    {
+                        "op": "normalize",
+                        "layout": "HWC",
+                        "shape": [128, 160, 3],
+                        "dtype": "float32",
+                        "reason": "first approval",
+                        "approved_by": "maintainer-a",
+                    },
+                    {
+                        "op": "normalize",
+                        "layout": "HWC",
+                        "shape": [128, 160, 3],
+                        "dtype": "float32",
+                        "reason": "second approval",
+                        "approved_by": "maintainer-b",
+                    },
+                ],
+            },
+        ),
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_benchmark_regressions.py",
+            "--baseline",
+            str(baseline),
+            "--current",
+            str(current),
+            "--mode",
+            "release",
+            "--accepted-regressions",
+            str(accepted),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="duplicate accepted regression keys"):
         check_benchmark_regressions.main()
 
 
@@ -303,6 +353,26 @@ def test_release_candidate_benchmark_evidence_rejects_wrong_baseline(tmp_path) -
         )
 
 
+def test_release_candidate_benchmark_evidence_rejects_duplicate_basenames(tmp_path) -> None:
+    evidence = tmp_path / "benchmark-evidence"
+    dist = tmp_path / "dist"
+    first = evidence / "first"
+    second = evidence / "second"
+    first.mkdir(parents=True)
+    second.mkdir()
+    (first / "router-current.json").write_text("{}")
+    (second / "router-current.json").write_text("{}")
+
+    with pytest.raises(ValueError, match="duplicate basename 'router-current.json'"):
+        validate_release_candidate.validate_reusable_benchmark_evidence(
+            evidence,
+            dist,
+            "abc123",
+            "0.2.2",
+            "0.1.6",
+        )
+
+
 def test_publish_artifact_verifier_checks_provenance_files_and_checksums(tmp_path) -> None:
     dist = tmp_path / "dist"
     dist.mkdir()
@@ -353,6 +423,48 @@ def test_publish_artifact_verifier_checks_provenance_files_and_checksums(tmp_pat
         verify_publish_artifacts.verify_checksums(dist)
 
 
+def test_publish_artifact_verifier_rejects_candidate_run_mismatches() -> None:
+    valid = {
+        "status": "completed",
+        "conclusion": "success",
+        "workflowName": "Release Candidate",
+        "headSha": "abc123",
+    }
+
+    with pytest.raises(ValueError, match="did not succeed"):
+        verify_publish_artifacts.verify_candidate_run({**valid, "conclusion": "failure"}, "abc123")
+    with pytest.raises(ValueError, match="expected 'Release Candidate'"):
+        verify_publish_artifacts.verify_candidate_run({**valid, "workflowName": "Other"}, "abc123")
+    with pytest.raises(ValueError, match="does not match abc123"):
+        verify_publish_artifacts.verify_candidate_run({**valid, "headSha": "deadbeef"}, "abc123")
+
+
+def test_publish_artifact_verifier_rejects_release_metadata_mismatches() -> None:
+    metadata = {"version": "0.2.2", "commit_sha": "abc123"}
+
+    with pytest.raises(ValueError, match="version"):
+        verify_publish_artifacts.verify_release_metadata({**metadata, "version": "0.2.3"}, "0.2.2", "abc123")
+    with pytest.raises(ValueError, match="SHA"):
+        verify_publish_artifacts.verify_release_metadata({**metadata, "commit_sha": "deadbeef"}, "0.2.2", "abc123")
+
+
+def test_publish_artifact_verifier_rejects_missing_and_malformed_checksums(tmp_path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="SHA256SUMS"):
+        verify_publish_artifacts.verify_checksums(dist)
+
+    checksums = dist / "SHA256SUMS.txt"
+    checksums.write_text("0" * 64 + "missing-separator")
+    with pytest.raises(ValueError, match="Malformed checksum line"):
+        verify_publish_artifacts.verify_checksums(dist)
+
+    checksums.write_text("0" * 10 + "  ./artifact.whl\n")
+    with pytest.raises(ValueError, match="Malformed sha256 digest"):
+        verify_publish_artifacts.verify_checksums(dist)
+
+
 class _FakeResponse:
     def __init__(self, payload: dict[str, object] | None = None, status: int = 200) -> None:
         self.payload = payload or {}
@@ -398,6 +510,27 @@ def test_publish_artifact_verifier_waits_for_pypi_files() -> None:
     )
 
     assert file_count == 1
+
+
+def test_publish_artifact_verifier_requires_pypi_urls_list() -> None:
+    with pytest.raises(TypeError, match="urls"):
+        verify_publish_artifacts.pypi_file_count({"urls": {"filename": "albucore-0.2.2.tar.gz"}})
+
+
+def test_publish_artifact_verifier_rejects_pypi_publication_without_files() -> None:
+    def empty_version(url: str, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(payload={"urls": []})
+
+    with pytest.raises(ValueError, match="metadata but no files"):
+        verify_publish_artifacts.verify_pypi_publication(
+            "albucore",
+            "0.2.2",
+            verify_publish_artifacts.PyPIWaitConfig(
+                attempts=1,
+                sleep_seconds=0.0,
+                urlopen=empty_version,
+            ),
+        )
 
 
 def test_benchmark_summary_reads_router_json(tmp_path, monkeypatch, capsys) -> None:

--- a/tools/check_benchmark_regressions.py
+++ b/tools/check_benchmark_regressions.py
@@ -140,6 +140,9 @@ def _load_accepted_regressions(
             tuple(int(part) for part in shape),
             _required_text(item, path, index, "dtype"),
         )
+        if key in accepted:
+            msg = f"{path} contains duplicate accepted regression keys for {key!r}."
+            raise ValueError(msg)
         accepted[key] = AcceptedRegression(
             reason=_required_text(item, path, index, "reason"),
             approved_by=_required_text(item, path, index, "approved_by"),
@@ -202,6 +205,20 @@ def _shape_text(shape: tuple[int, ...]) -> str:
     return "x".join(str(part) for part in shape)
 
 
+def _markdown_code_cell(value: str | None) -> str:
+    text = (value or "").replace("\n", " ").replace("|", r"\|")
+    longest_backtick_run = 0
+    current_run = 0
+    for character in text:
+        if character == "`":
+            current_run += 1
+            longest_backtick_run = max(longest_backtick_run, current_run)
+        else:
+            current_run = 0
+    delimiter = "`" * (longest_backtick_run + 1)
+    return f"{delimiter}{text}{delimiter}"
+
+
 def _markdown_report(
     baseline_path: Path,
     current_path: Path,
@@ -251,7 +268,7 @@ def _markdown_report(
         cell = regression.cell
         lines.append(
             f"| `{cell.op}` | `{cell.layout}` | `{_shape_text(cell.shape)}` | `{cell.dtype}` | "
-            f"{regression.accepted_by} | {regression.accepted_reason} |",
+            f"{_markdown_code_cell(regression.accepted_by)} | {_markdown_code_cell(regression.accepted_reason)} |",
         )
     if not accepted_regressions:
         lines.append("| none | none | none | none | none | none |")

--- a/tools/validate_release_candidate.py
+++ b/tools/validate_release_candidate.py
@@ -244,7 +244,17 @@ def validate_benchmark_metadata(
 
 
 def _evidence_files(evidence_dir: Path) -> dict[str, Path]:
-    return {path.name: path for path in evidence_dir.rglob("*") if path.is_file()}
+    evidence_files: dict[str, Path] = {}
+    for path in sorted((candidate for candidate in evidence_dir.rglob("*") if candidate.is_file()), key=str):
+        existing = evidence_files.get(path.name)
+        if existing is not None:
+            msg = (
+                f"Reusable benchmark evidence contains duplicate basename {path.name!r}: "
+                f"{existing.relative_to(evidence_dir)} and {path.relative_to(evidence_dir)}."
+            )
+            raise ValueError(msg)
+        evidence_files[path.name] = path
+    return evidence_files
 
 
 def validate_reusable_benchmark_evidence(


### PR DESCRIPTION
## Summary
- fail on duplicate reusable benchmark evidence basenames
- fail on duplicate accepted-regression keys
- escape accepted-regression rationale Markdown cells
- add failure-mode tests for candidate-run provenance, release metadata, checksums, and PyPI polling

## Verification
- uv run pytest tests/test_verification_tools.py
- uv run python tools/ci_matrix.py check
- pre-commit run --all-files
- uv run pytest

## Summary by Sourcery

Harden release verification and reporting around benchmark regressions and artifact publishing edge cases.

Bug Fixes:
- Reject duplicate accepted regression entries by key when loading benchmark regression metadata.
- Reject reusable benchmark evidence that contains files with duplicate basenames.
- Ensure Markdown report cells escape pipes and handle backticks safely in accepted regression rationale and approver fields.
- Tighten validation of release candidate workflow provenance, release metadata, checksum files, and PyPI publication responses, raising clear errors on mismatches or malformed data.

Tests:
- Add regression tests covering duplicate accepted regression keys and duplicate benchmark evidence basenames.
- Add tests for failure modes in candidate-run verification, release metadata validation, checksum presence and formatting, and PyPI polling without files.