### PR TITLE
Add separate Albucore CLA v1 and legal integrity gates

### DIFF
--- a/.github/workflows/legal-integrity.yml
+++ b/.github/workflows/legal-integrity.yml
@@ -1,0 +1,43 @@
+name: Legal Integrity
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  legal_integrity:
+    name: License, CLA, and package notices
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.11"
+          activate-environment: true
+
+      - name: Verify source-tree legal integrity
+        run: python tools/verify_legal_integrity.py
+
+      - name: Test legal-integrity verifier
+        run: uv run --no-project --with pytest pytest --noconftest -q tests/test_legal_integrity.py
+
+      - name: Build wheel and source distribution
+        run: uv build --out-dir "${RUNNER_TEMP}/albucore-legal-dist"
+
+      - name: Verify distribution license and CLA exclusion
+        run: >-
+          python tools/verify_legal_integrity.py --artifacts
+          "${RUNNER_TEMP}"/albucore-legal-dist/*.whl
+          "${RUNNER_TEMP}"/albucore-legal-dist/*.tar.gz
+
+      - name: Check distribution metadata
+        run: uv tool run --from twine twine check "${RUNNER_TEMP}"/albucore-legal-dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
           run-id: ${{ inputs.candidate_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Verify distribution license and CLA integrity
+        run: python tools/verify_legal_integrity.py --artifacts dist/*.whl dist/*.tar.gz
+
       - name: Verify release candidate provenance and artifacts
         env:
           REQUESTED_VERSION: ${{ inputs.version }}
@@ -147,8 +150,14 @@ jobs:
           python tools/validate_release_candidate.py ci-runs \
             --runs-json /tmp/albucore-ci-runs.json
 
+      - name: Verify license and CLA provenance
+        run: python tools/verify_legal_integrity.py
+
       - name: Build distributions
         run: uv build
+
+      - name: Verify distribution license and CLA integrity
+        run: python tools/verify_legal_integrity.py --artifacts dist/*.whl dist/*.tar.gz
 
       - name: Install release validation dependencies
         run: uv sync --frozen --extra headless --group dev

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -63,8 +63,14 @@ jobs:
           python tools/validate_release_candidate.py ci-runs \
             --runs-json /tmp/albucore-ci-runs.json
 
+      - name: Verify license and CLA provenance
+        run: python tools/verify_legal_integrity.py
+
       - name: Build distributions
         run: uv build
+
+      - name: Verify distribution license and CLA integrity
+        run: python tools/verify_legal_integrity.py --artifacts dist/*.whl dist/*.tar.gz
 
       - name: Install release validation dependencies
         run: uv sync --frozen --extra headless --group dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,12 @@ repos:
         entry: uv lock --check
         language: system
         pass_filenames: false
+      - id: check-legal-integrity
+        name: Check license and CLA provenance integrity
+        entry: python tools/verify_legal_integrity.py
+        language: system
+        pass_filenames: false
+        files: ^(LICENSE$|CLA\.md$|CONTRIBUTING\.md$|README\.md$|legal/cla/|pyproject\.toml$|docs/maintaining/license-provenance\.md$|tools/verify_legal_integrity\.py$|tests/test_legal_integrity\.py$|\.github/workflows/(legal-integrity|release-candidate|publish)\.yml$)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         entry: python tools/verify_legal_integrity.py
         language: system
         pass_filenames: false
-        files: ^(LICENSE$|CLA\.md$|CONTRIBUTING\.md$|README\.md$|legal/cla/|pyproject\.toml$|docs/maintaining/license-provenance\.md$|tools/verify_legal_integrity\.py$|tests/test_legal_integrity\.py$|\.github/workflows/(legal-integrity|release-candidate|publish)\.yml$)
+        always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,310 @@
+# Albucore Contributor License Agreement
+
+**Version 1.0 — July 14, 2026**
+
+This Contributor License Agreement (the **Agreement**) is between the person or
+legal entity accepting it (**You**) and **Albumentations, LLC**, a Delaware
+limited liability company (**Albumentations**, **We**, or **Us**).
+
+## Plain-English Summary
+
+This Agreement does not transfer ownership of a contribution. You grant
+Albumentations broad copyright and patent permissions needed to maintain
+Albucore, publish accepted contributions in the public Albucore project under
+the MIT License, and license or sublicense them under commercial, proprietary,
+or other terms. An accepted contribution remains available in the public
+project under the MIT License even when it is also licensed under other terms.
+
+This version applies only after You expressly accept **Version 1.0**. A
+repository change, an acceptance by another person, or acceptance of a CLA for
+another project does not bind You. When You accept Version 1.0, the grants cover
+Your qualifying contributions from before, on, and after the acceptance date as
+described below.
+
+This summary is explanatory. The sections below are the Agreement.
+
+## 1. Definitions
+
+1. **Acceptance Record** means the durable record showing the Agreement
+   version, acceptance date, accepting person or entity, and the identity or
+   identities whose Contributions are covered.
+2. **Contribution** means any work of authorship, including source code, object
+   code, documentation, tests, designs, data, or other material, that is
+   intentionally Submitted for inclusion in the Material. A communication
+   conspicuously marked in writing as "Not a Contribution" is excluded.
+3. **Covered Contribution** means a Contribution Submitted before, on, or after
+   the Acceptance Date: (a) by You, for an Individual Acceptance; or (b) by a
+   Covered Contributor acting within the scope and covered period identified in
+   an Entity Acceptance Record, for an Entity Acceptance. In either case, You
+   must own, control, or have authority to grant the rights needed to make the
+   grants in this Agreement.
+4. **Covered Contributor** means an individual identified in an Entity
+   Acceptance Record by legal name, GitHub username, or another unambiguous
+   identifier.
+5. **Entity** means the exact corporation, limited liability company,
+   partnership, organization, or other legal entity identified in an Entity
+   Acceptance Record. A parent, subsidiary, affiliate, or entity under common
+   control is not covered unless it is separately named and the accepting
+   representative expressly states that they have authority to bind it.
+6. **Material** means the Albucore project maintained in the Project Repository
+   and any work based on or incorporating a Covered Contribution.
+7. **MIT License** means the license text headed "MIT License" in the root
+   `LICENSE` file of the Project Repository as of July 14, 2026.
+8. **Project Repository** means
+   `https://github.com/albumentations-team/albucore`.
+9. **Submit** means intentionally sending material to the Project Repository,
+   including its pull requests, issue tracker, or code-review system, or to
+   another channel explicitly designated by Albumentations for the purpose of
+   discussing or improving the Material. For an Individual Acceptance, You
+   perform that act. For an Entity Acceptance, a Covered Contributor performs
+   that act within the scope and covered period identified in the Entity
+   Acceptance Record.
+10. **Acceptance Date** means the timestamp recorded in the Acceptance Record.
+
+## 2. Who Is Accepting
+
+### 2.1 Individual Acceptance
+
+If You accept as an individual, You accept for Yourself only. Your acceptance
+does not grant rights in material owned by Your employer or another Entity. If
+an Entity owns or controls rights needed for a Contribution, that Entity must
+accept through Section 2.2 or otherwise authorize the grant in writing.
+
+### 2.2 Entity Acceptance
+
+An Entity may accept through an authorized representative. The representative
+must identify the Entity's exact legal name, their name and title, and the
+Covered Contributors. The Acceptance Record must also identify the authorized
+contribution scope, the covered period (including the start date for any
+earlier Contributions), and known GitHub identities or aliases used to Submit.
+The representative states that they have authority to bind the Entity and to
+make the grants and representations in this Agreement.
+
+An Entity Acceptance covers future Contributions only while the contributor is
+a Covered Contributor acting within the authorized scope. The Entity must
+notify Albumentations when a Covered Contributor should be added or removed.
+Removal is prospective and does not withdraw grants for Contributions already
+covered.
+
+## 3. Ownership
+
+This Agreement is a license, not an assignment, and does not transfer ownership
+of a Covered Contribution. Ownership remains with You or the applicable rights
+holder. Except for the rights expressly granted here, nothing in this Agreement
+limits any rights that You or that rights holder otherwise has to use or license
+the Covered Contribution.
+
+## 4. Copyright License
+
+For every Covered Contribution, You grant to Albumentations and its successors
+and assigns a perpetual, worldwide, non-exclusive, transferable, irrevocable,
+royalty-free, fully paid-up copyright license, with the right to sublicense
+through multiple tiers, to:
+
+- reproduce, use, host, modify, adapt, translate, and create derivative works;
+- publish, publicly display, publicly perform, make available, distribute,
+  import, and otherwise communicate or transfer the Covered Contribution;
+- combine it with other material and exercise the foregoing rights in any media
+  or format; and
+- license or sublicense it under open-source, source-available, commercial,
+  proprietary, or other terms, including for a fee.
+
+To the extent You own or control moral rights, droit moral, or similar rights,
+You waive and agree not to assert them against Albumentations, its successors,
+its sublicensees, or recipients exercising rights granted under this Agreement.
+Where waiver is not permitted, You grant the broadest consent allowed by law to
+the same acts. An Entity Acceptance does not purport to waive a natural
+author's personal rights that the Entity does not own or control; Section 7.3
+requires the Entity to have obtained the assignments, waivers, or consents
+needed for the licensed uses.
+
+## 5. Patent License
+
+You grant to Albumentations and its successors and assigns a perpetual,
+worldwide, non-exclusive, transferable, irrevocable, royalty-free, fully paid-up
+patent license, with the right to sublicense through multiple tiers, to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the Covered
+Contribution and the Covered Contribution in combination with the Material.
+
+This patent grant applies only to patent claims that You now or later own or
+control, or have the right to grant, and that are necessarily infringed by the
+Covered Contribution alone or by its combination with the Material to which it
+was Submitted.
+
+## 6. Outbound Licensing and Public Availability
+
+Albumentations may license or sublicense Covered Contributions, alone or as
+part of the Material, under the MIT License and under commercial, proprietary,
+source-available, or other terms, including for a fee. The grants in Sections 4
+and 5 expressly authorize those outbound licensing choices.
+
+As a condition of exercising the right to license or sublicense a Covered
+Contribution under any terms other than the MIT License, Albumentations will
+first or simultaneously make the accepted version of that Covered Contribution
+available as part of a public Albucore revision in the Project Repository under
+the MIT License. Removal from a later revision does not revoke the MIT License
+already granted for a public revision.
+
+Nothing in this Agreement revokes or narrows an open-source license previously
+granted for a Contribution or for any project revision.
+
+## 7. Your Representations
+
+### 7.1 Representations for Every Acceptance
+
+You represent that:
+
+1. You have legal authority to accept this Agreement and make its grants.
+2. You own or control the copyrights and patent rights needed for each Covered
+   Contribution, or You have obtained written authority from the relevant
+   rights holder.
+3. Third-party material is clearly identified together with its source and
+   license.
+4. Your grants do not violate an agreement binding You or, for an Entity
+   Acceptance, a Covered Contributor.
+5. You will notify Albumentations promptly if You learn that a representation
+   in this section was materially incorrect when made.
+
+### 7.2 Additional Individual Representations
+
+For an Individual Acceptance, You also represent that, to Your knowledge, each
+Covered Contribution is Your original work except for identified third-party
+material. If an employer, client, funding source, or other Entity owns or
+controls relevant rights, You have obtained its written authority before
+Submitting the Contribution. You also represent that You have reached the age
+of legal majority and otherwise have legal capacity to accept this Agreement.
+
+### 7.3 Additional Entity Representations
+
+For an Entity Acceptance, the representative personally represents only that
+they have authority to bind every exact legal entity named in the Acceptance
+Record. The Entity represents that:
+
+1. Each Covered Contributor acted within the scope and covered period identified
+   in the Acceptance Record when Submitting a Covered Contribution.
+2. The Entity owns, controls, or has written authority to grant the rights
+   needed under this Agreement for those Covered Contributions.
+3. To the extent a natural author retains personal moral or similar rights, the
+   Entity has obtained the assignments, waivers, non-assertion commitments, or
+   consents needed for Albumentations and its sublicensees to exercise the
+   licensed rights.
+4. To the Entity's knowledge, each Covered Contribution is original to a
+   Covered Contributor except for identified third-party material.
+
+You are not required to perform a patent search. Contributions are otherwise
+provided **AS IS**, without warranties or conditions of any kind, express or
+implied, including merchantability, fitness for a particular purpose, title,
+and non-infringement, to the extent those disclaimers are permitted by law.
+
+## 8. Contributor Consequential-Damages Waiver
+
+To the maximum extent permitted by applicable law, You will not be liable to
+Albumentations, or to a person claiming through Albumentations, for lost
+profits, lost revenue, lost anticipated savings, lost data, or indirect,
+special, incidental, consequential, or exemplary damages arising from this
+Agreement under any legal or equitable theory, even if advised that those
+damages were possible. This section does not limit direct-damages or equitable
+remedies for a breach of the ownership, authority, or license representations
+and grants in this Agreement.
+
+## 9. Project Discretion and No Services
+
+Albumentations is not required to accept, use, distribute, maintain, or support
+a Contribution. This Agreement does not create employment, agency, partnership,
+support, maintenance, warranty, or service-level obligations.
+
+## 10. Term and Future Contributions
+
+This Agreement begins on the Acceptance Date. The grants for Covered
+Contributions Submitted before or on that date take effect on that date. This
+is an express present grant for identified earlier Contributions; it is not a
+claim that Version 1.0 was accepted before the Acceptance Date.
+
+You may end coverage for future Contributions by written notice to
+`vladimir@albumentations.ai`. Termination becomes effective 30 days after
+receipt. Grants and other provisions relating to Covered Contributions
+Submitted before the effective termination date survive and remain
+irrevocable. A later Contribution requires a new acceptance or other written
+agreement.
+
+## 11. Agreement Versions and Acceptance Records
+
+Each project and CLA version is a separate offer. Acceptance of the
+AlbumentationsX CLA or another contributor agreement does not constitute
+acceptance of this Albucore CLA. Acceptance of Version 1.0 does not by itself
+constitute acceptance of a later version.
+
+Albumentations will preserve the operative text and an identifier for each
+version in `legal/cla/archive/` and preserve Acceptance Records outside release
+artifacts.
+
+The exact Version 1.0 acceptance methods are listed in the **Acceptance
+Instructions** below. Albumentations may offer another method only if the
+resulting record identifies Version 1.0 and captures the information required
+for an Individual or Entity Acceptance.
+
+## 12. General Terms
+
+1. This Agreement is the entire agreement concerning its subject and replaces
+   prior discussions about the same grants, but it does not revoke licenses
+   already granted to the public.
+2. Any amendment requires a new written or electronic acceptance that
+   identifies the amended version. A repository edit alone is not an amendment
+   accepted by You.
+3. You may not assign this Agreement without Albumentations' written consent,
+   except to a successor to substantially all assets associated with the
+   Covered Contributions. Albumentations may assign this Agreement with the
+   Material or to a successor to substantially all related assets. Any permitted
+   assignee must assume the assigning party's obligations in writing. An
+   Albumentations assignee must expressly assume the public-availability
+   obligation in Section 6.
+4. If a provision is unenforceable, it will be limited to the minimum extent
+   necessary, and the remaining provisions remain effective.
+5. A waiver must be in writing and applies only to the stated instance.
+6. This Agreement is governed by Delaware law, excluding its conflict-of-law
+   rules. The state and federal courts located in Delaware have exclusive
+   jurisdiction, and each party consents to that jurisdiction and venue.
+7. Electronic acceptance and records have the same effect as originals.
+
+## Acceptance Instructions
+
+### Individual
+
+Use this path only if You have reached the age of legal majority and otherwise
+have legal capacity to accept this Agreement. If not, do not use the
+pull-request signing form; contact `vladimir@albumentations.ai` for a separate
+capacity and parent-or-guardian process appropriate to Your circumstances.
+
+After reading this exact Version 1.0, use the CLA Assistant link on the pull
+request, enter Your full legal name, and accept this statement:
+
+```text
+I have read and agree to the Albucore CLA Version 1.0 (July 14, 2026) as an individual.
+```
+
+The Acceptance Record must retain the full legal name, GitHub identity,
+timestamp, exact acceptance statement, repository and pull request, and the
+Version 1.0 identifier from `legal/cla/archive/MANIFEST.md`.
+
+### Entity
+
+An authorized representative must send the following information from a
+verifiable business address to `vladimir@albumentations.ai`, or provide it
+through another corporate-signing workflow that records the same fields:
+
+```text
+Entity legal name:
+Representative name:
+Representative title:
+Covered Contributor legal name(s):
+Covered Contributor GitHub username(s):
+Prior GitHub username(s) or other submission aliases, if any:
+Authorized contribution scope (repositories, projects, or roles):
+Covered period/start date (identify any earlier Contributions included):
+
+I am authorized to bind the Entity identified above, and the Entity agrees to
+the Albucore CLA Version 1.0 (July 14, 2026).
+```
+
+An individual contributor must use the Individual statement unless a completed
+Entity Acceptance Record already covers that contributor and Contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Albucore
+
+Thank you for contributing to Albucore.
+
+Small bug fixes, tests, and documentation changes can go directly to a pull
+request. Open an issue before adding public APIs or changing performance
+routing so maintainers can agree on behavior and benchmark scope.
+
+Follow [AGENTS.md](AGENTS.md) and the relevant files in [`docs/`](docs/). Add
+tests for affected dtypes and image shapes. Include benchmark evidence when
+changing backend selection.
+
+## Contributor License Agreement
+
+Before a pull request can be merged, the applicable rights holder must accept
+the [Albucore Contributor License Agreement Version 1.0](CLA.md). You retain
+ownership of your contribution. The CLA gives Albumentations, LLC the copyright
+and patent permissions described in the agreement, including permission to
+distribute covered contributions under MIT and other terms.
+
+Albucore remains publicly available under the [MIT License](LICENSE), including
+contributions accepted under this CLA. Adopting the CLA does not change the
+repository's license or automatically cover historical contributions.
+Historical contributions remain available under MIT and become CLA-covered
+only through an applicable Version 1.0 Acceptance Record.
+
+### Individual acceptance
+
+Use this path only when you own or control the rights needed for your
+contribution. Open a pull request, follow the CLA Assistant link in the
+`license/cla` check or bot comment, provide your full legal name, and confirm:
+
+```text
+I have read and agree to the Albucore CLA Version 1.0 (July 14, 2026) as an individual.
+```
+
+### Entity acceptance
+
+If an employer or another legal entity owns or controls the rights needed for
+the contribution, do not use the individual path. An authorized representative
+must follow the Entity Acceptance instructions in [CLA.md](CLA.md) and send the
+completed statement from a verifiable business address to
+`vladimir@albumentations.ai`.
+
+Maintainers verify the applicable Version 1.0 Acceptance Record before merge.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ See [docs/performance-optimization.md](docs/performance-optimization.md) for det
 
 ## Documentation
 
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Pull request process and CLA acceptance paths
 - [AGENTS.md](AGENTS.md) - AI development guidelines for working with this codebase
 - [docs/image-conventions.md](docs/image-conventions.md) - Image shape conventions and requirements
 - [docs/decorators.md](docs/decorators.md) - Decorator usage and patterns
@@ -221,7 +222,13 @@ See [docs/performance-optimization.md](docs/performance-optimization.md) for det
 
 ## License
 
-MIT
+Albucore is publicly available under the [MIT License](LICENSE), including
+contributions accepted under the
+[Albucore Contributor License Agreement Version 1.0](CLA.md). The CLA does not
+change the repository's public license. Historical contributions remain
+available under MIT and become CLA-covered only through an applicable Version
+1.0 Acceptance Record. See [CONTRIBUTING.md](CONTRIBUTING.md) for the individual
+CLA Assistant and entity acceptance paths.
 
 ## Acknowledgements
 

--- a/docs/maintaining/license-provenance.md
+++ b/docs/maintaining/license-provenance.md
@@ -1,0 +1,63 @@
+# Maintaining Albucore License and CLA Records
+
+Albucore's public license and its inbound Contributor License Agreement serve
+different purposes:
+
+- [`LICENSE`](../../LICENSE) is the MIT license for the public repository and
+  distributed package.
+- [`CLA.md`](../../CLA.md) records additional copyright, patent, authority, and
+  sublicensing grants from contributors to Albumentations, LLC.
+
+The CLA does not replace or narrow MIT permissions. Every accepted contribution
+covered by the CLA must first or simultaneously appear in a public Albucore
+revision under MIT before Albumentations uses the additional outbound rights.
+
+## Versioning the CLA
+
+Treat the root `CLA.md`, its archived copy, and the hosted CLA Assistant Gist as
+one versioned offer.
+
+1. Never edit an operative CLA version in place.
+2. Create a new version and dated archive file for any substantive change.
+3. Record the exact byte length and SHA-256 digest in
+   [`legal/cla/archive/MANIFEST.md`](../../legal/cla/archive/MANIFEST.md).
+4. Create a new immutable Gist revision containing the byte-identical CLA and
+   its acceptance-field metadata.
+5. Preserve prior Gist revisions and private signer exports.
+6. Require contributors to accept the new version explicitly; an earlier or
+   project-specific CLA acceptance does not silently carry forward.
+
+AlbumentationsX uses a different CLA and Gist. Do not link its AGPL-specific
+agreement to Albucore.
+
+## Acceptance records
+
+CLA Assistant handles the individual path. The hosted form must collect the
+signer's full legal name and the exact versioned acceptance statement.
+Authorized entity acceptances use the fields in `CLA.md` and are handled
+separately through `vladimir@albumentations.ai`.
+
+Signer exports and entity records contain personal or contractual information.
+Store them in access-controlled private storage. Do not commit them to this
+repository or include them in release artifacts.
+
+## Repository and release checks
+
+Run the source verifier before committing legal or packaging changes:
+
+```bash
+python tools/verify_legal_integrity.py
+```
+
+Build and inspect both distribution formats before a release:
+
+```bash
+uv build
+python tools/verify_legal_integrity.py --artifacts dist/*.whl dist/*.tar.gz
+```
+
+The verifier enforces the MIT metadata and license bytes, the current CLA hash
+and archive, packaging exclusions for inbound/private material, and the absence
+of nested distribution artifacts. The `main` ruleset must require both hosted
+`license/cla` and the GitHub Actions check named
+`License, CLA, and package notices`.

--- a/legal/cla/archive/CLA-v1.0-2026-07-14.md
+++ b/legal/cla/archive/CLA-v1.0-2026-07-14.md
@@ -1,0 +1,310 @@
+# Albucore Contributor License Agreement
+
+**Version 1.0 — July 14, 2026**
+
+This Contributor License Agreement (the **Agreement**) is between the person or
+legal entity accepting it (**You**) and **Albumentations, LLC**, a Delaware
+limited liability company (**Albumentations**, **We**, or **Us**).
+
+## Plain-English Summary
+
+This Agreement does not transfer ownership of a contribution. You grant
+Albumentations broad copyright and patent permissions needed to maintain
+Albucore, publish accepted contributions in the public Albucore project under
+the MIT License, and license or sublicense them under commercial, proprietary,
+or other terms. An accepted contribution remains available in the public
+project under the MIT License even when it is also licensed under other terms.
+
+This version applies only after You expressly accept **Version 1.0**. A
+repository change, an acceptance by another person, or acceptance of a CLA for
+another project does not bind You. When You accept Version 1.0, the grants cover
+Your qualifying contributions from before, on, and after the acceptance date as
+described below.
+
+This summary is explanatory. The sections below are the Agreement.
+
+## 1. Definitions
+
+1. **Acceptance Record** means the durable record showing the Agreement
+   version, acceptance date, accepting person or entity, and the identity or
+   identities whose Contributions are covered.
+2. **Contribution** means any work of authorship, including source code, object
+   code, documentation, tests, designs, data, or other material, that is
+   intentionally Submitted for inclusion in the Material. A communication
+   conspicuously marked in writing as "Not a Contribution" is excluded.
+3. **Covered Contribution** means a Contribution Submitted before, on, or after
+   the Acceptance Date: (a) by You, for an Individual Acceptance; or (b) by a
+   Covered Contributor acting within the scope and covered period identified in
+   an Entity Acceptance Record, for an Entity Acceptance. In either case, You
+   must own, control, or have authority to grant the rights needed to make the
+   grants in this Agreement.
+4. **Covered Contributor** means an individual identified in an Entity
+   Acceptance Record by legal name, GitHub username, or another unambiguous
+   identifier.
+5. **Entity** means the exact corporation, limited liability company,
+   partnership, organization, or other legal entity identified in an Entity
+   Acceptance Record. A parent, subsidiary, affiliate, or entity under common
+   control is not covered unless it is separately named and the accepting
+   representative expressly states that they have authority to bind it.
+6. **Material** means the Albucore project maintained in the Project Repository
+   and any work based on or incorporating a Covered Contribution.
+7. **MIT License** means the license text headed "MIT License" in the root
+   `LICENSE` file of the Project Repository as of July 14, 2026.
+8. **Project Repository** means
+   `https://github.com/albumentations-team/albucore`.
+9. **Submit** means intentionally sending material to the Project Repository,
+   including its pull requests, issue tracker, or code-review system, or to
+   another channel explicitly designated by Albumentations for the purpose of
+   discussing or improving the Material. For an Individual Acceptance, You
+   perform that act. For an Entity Acceptance, a Covered Contributor performs
+   that act within the scope and covered period identified in the Entity
+   Acceptance Record.
+10. **Acceptance Date** means the timestamp recorded in the Acceptance Record.
+
+## 2. Who Is Accepting
+
+### 2.1 Individual Acceptance
+
+If You accept as an individual, You accept for Yourself only. Your acceptance
+does not grant rights in material owned by Your employer or another Entity. If
+an Entity owns or controls rights needed for a Contribution, that Entity must
+accept through Section 2.2 or otherwise authorize the grant in writing.
+
+### 2.2 Entity Acceptance
+
+An Entity may accept through an authorized representative. The representative
+must identify the Entity's exact legal name, their name and title, and the
+Covered Contributors. The Acceptance Record must also identify the authorized
+contribution scope, the covered period (including the start date for any
+earlier Contributions), and known GitHub identities or aliases used to Submit.
+The representative states that they have authority to bind the Entity and to
+make the grants and representations in this Agreement.
+
+An Entity Acceptance covers future Contributions only while the contributor is
+a Covered Contributor acting within the authorized scope. The Entity must
+notify Albumentations when a Covered Contributor should be added or removed.
+Removal is prospective and does not withdraw grants for Contributions already
+covered.
+
+## 3. Ownership
+
+This Agreement is a license, not an assignment, and does not transfer ownership
+of a Covered Contribution. Ownership remains with You or the applicable rights
+holder. Except for the rights expressly granted here, nothing in this Agreement
+limits any rights that You or that rights holder otherwise has to use or license
+the Covered Contribution.
+
+## 4. Copyright License
+
+For every Covered Contribution, You grant to Albumentations and its successors
+and assigns a perpetual, worldwide, non-exclusive, transferable, irrevocable,
+royalty-free, fully paid-up copyright license, with the right to sublicense
+through multiple tiers, to:
+
+- reproduce, use, host, modify, adapt, translate, and create derivative works;
+- publish, publicly display, publicly perform, make available, distribute,
+  import, and otherwise communicate or transfer the Covered Contribution;
+- combine it with other material and exercise the foregoing rights in any media
+  or format; and
+- license or sublicense it under open-source, source-available, commercial,
+  proprietary, or other terms, including for a fee.
+
+To the extent You own or control moral rights, droit moral, or similar rights,
+You waive and agree not to assert them against Albumentations, its successors,
+its sublicensees, or recipients exercising rights granted under this Agreement.
+Where waiver is not permitted, You grant the broadest consent allowed by law to
+the same acts. An Entity Acceptance does not purport to waive a natural
+author's personal rights that the Entity does not own or control; Section 7.3
+requires the Entity to have obtained the assignments, waivers, or consents
+needed for the licensed uses.
+
+## 5. Patent License
+
+You grant to Albumentations and its successors and assigns a perpetual,
+worldwide, non-exclusive, transferable, irrevocable, royalty-free, fully paid-up
+patent license, with the right to sublicense through multiple tiers, to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the Covered
+Contribution and the Covered Contribution in combination with the Material.
+
+This patent grant applies only to patent claims that You now or later own or
+control, or have the right to grant, and that are necessarily infringed by the
+Covered Contribution alone or by its combination with the Material to which it
+was Submitted.
+
+## 6. Outbound Licensing and Public Availability
+
+Albumentations may license or sublicense Covered Contributions, alone or as
+part of the Material, under the MIT License and under commercial, proprietary,
+source-available, or other terms, including for a fee. The grants in Sections 4
+and 5 expressly authorize those outbound licensing choices.
+
+As a condition of exercising the right to license or sublicense a Covered
+Contribution under any terms other than the MIT License, Albumentations will
+first or simultaneously make the accepted version of that Covered Contribution
+available as part of a public Albucore revision in the Project Repository under
+the MIT License. Removal from a later revision does not revoke the MIT License
+already granted for a public revision.
+
+Nothing in this Agreement revokes or narrows an open-source license previously
+granted for a Contribution or for any project revision.
+
+## 7. Your Representations
+
+### 7.1 Representations for Every Acceptance
+
+You represent that:
+
+1. You have legal authority to accept this Agreement and make its grants.
+2. You own or control the copyrights and patent rights needed for each Covered
+   Contribution, or You have obtained written authority from the relevant
+   rights holder.
+3. Third-party material is clearly identified together with its source and
+   license.
+4. Your grants do not violate an agreement binding You or, for an Entity
+   Acceptance, a Covered Contributor.
+5. You will notify Albumentations promptly if You learn that a representation
+   in this section was materially incorrect when made.
+
+### 7.2 Additional Individual Representations
+
+For an Individual Acceptance, You also represent that, to Your knowledge, each
+Covered Contribution is Your original work except for identified third-party
+material. If an employer, client, funding source, or other Entity owns or
+controls relevant rights, You have obtained its written authority before
+Submitting the Contribution. You also represent that You have reached the age
+of legal majority and otherwise have legal capacity to accept this Agreement.
+
+### 7.3 Additional Entity Representations
+
+For an Entity Acceptance, the representative personally represents only that
+they have authority to bind every exact legal entity named in the Acceptance
+Record. The Entity represents that:
+
+1. Each Covered Contributor acted within the scope and covered period identified
+   in the Acceptance Record when Submitting a Covered Contribution.
+2. The Entity owns, controls, or has written authority to grant the rights
+   needed under this Agreement for those Covered Contributions.
+3. To the extent a natural author retains personal moral or similar rights, the
+   Entity has obtained the assignments, waivers, non-assertion commitments, or
+   consents needed for Albumentations and its sublicensees to exercise the
+   licensed rights.
+4. To the Entity's knowledge, each Covered Contribution is original to a
+   Covered Contributor except for identified third-party material.
+
+You are not required to perform a patent search. Contributions are otherwise
+provided **AS IS**, without warranties or conditions of any kind, express or
+implied, including merchantability, fitness for a particular purpose, title,
+and non-infringement, to the extent those disclaimers are permitted by law.
+
+## 8. Contributor Consequential-Damages Waiver
+
+To the maximum extent permitted by applicable law, You will not be liable to
+Albumentations, or to a person claiming through Albumentations, for lost
+profits, lost revenue, lost anticipated savings, lost data, or indirect,
+special, incidental, consequential, or exemplary damages arising from this
+Agreement under any legal or equitable theory, even if advised that those
+damages were possible. This section does not limit direct-damages or equitable
+remedies for a breach of the ownership, authority, or license representations
+and grants in this Agreement.
+
+## 9. Project Discretion and No Services
+
+Albumentations is not required to accept, use, distribute, maintain, or support
+a Contribution. This Agreement does not create employment, agency, partnership,
+support, maintenance, warranty, or service-level obligations.
+
+## 10. Term and Future Contributions
+
+This Agreement begins on the Acceptance Date. The grants for Covered
+Contributions Submitted before or on that date take effect on that date. This
+is an express present grant for identified earlier Contributions; it is not a
+claim that Version 1.0 was accepted before the Acceptance Date.
+
+You may end coverage for future Contributions by written notice to
+`vladimir@albumentations.ai`. Termination becomes effective 30 days after
+receipt. Grants and other provisions relating to Covered Contributions
+Submitted before the effective termination date survive and remain
+irrevocable. A later Contribution requires a new acceptance or other written
+agreement.
+
+## 11. Agreement Versions and Acceptance Records
+
+Each project and CLA version is a separate offer. Acceptance of the
+AlbumentationsX CLA or another contributor agreement does not constitute
+acceptance of this Albucore CLA. Acceptance of Version 1.0 does not by itself
+constitute acceptance of a later version.
+
+Albumentations will preserve the operative text and an identifier for each
+version in `legal/cla/archive/` and preserve Acceptance Records outside release
+artifacts.
+
+The exact Version 1.0 acceptance methods are listed in the **Acceptance
+Instructions** below. Albumentations may offer another method only if the
+resulting record identifies Version 1.0 and captures the information required
+for an Individual or Entity Acceptance.
+
+## 12. General Terms
+
+1. This Agreement is the entire agreement concerning its subject and replaces
+   prior discussions about the same grants, but it does not revoke licenses
+   already granted to the public.
+2. Any amendment requires a new written or electronic acceptance that
+   identifies the amended version. A repository edit alone is not an amendment
+   accepted by You.
+3. You may not assign this Agreement without Albumentations' written consent,
+   except to a successor to substantially all assets associated with the
+   Covered Contributions. Albumentations may assign this Agreement with the
+   Material or to a successor to substantially all related assets. Any permitted
+   assignee must assume the assigning party's obligations in writing. An
+   Albumentations assignee must expressly assume the public-availability
+   obligation in Section 6.
+4. If a provision is unenforceable, it will be limited to the minimum extent
+   necessary, and the remaining provisions remain effective.
+5. A waiver must be in writing and applies only to the stated instance.
+6. This Agreement is governed by Delaware law, excluding its conflict-of-law
+   rules. The state and federal courts located in Delaware have exclusive
+   jurisdiction, and each party consents to that jurisdiction and venue.
+7. Electronic acceptance and records have the same effect as originals.
+
+## Acceptance Instructions
+
+### Individual
+
+Use this path only if You have reached the age of legal majority and otherwise
+have legal capacity to accept this Agreement. If not, do not use the
+pull-request signing form; contact `vladimir@albumentations.ai` for a separate
+capacity and parent-or-guardian process appropriate to Your circumstances.
+
+After reading this exact Version 1.0, use the CLA Assistant link on the pull
+request, enter Your full legal name, and accept this statement:
+
+```text
+I have read and agree to the Albucore CLA Version 1.0 (July 14, 2026) as an individual.
+```
+
+The Acceptance Record must retain the full legal name, GitHub identity,
+timestamp, exact acceptance statement, repository and pull request, and the
+Version 1.0 identifier from `legal/cla/archive/MANIFEST.md`.
+
+### Entity
+
+An authorized representative must send the following information from a
+verifiable business address to `vladimir@albumentations.ai`, or provide it
+through another corporate-signing workflow that records the same fields:
+
+```text
+Entity legal name:
+Representative name:
+Representative title:
+Covered Contributor legal name(s):
+Covered Contributor GitHub username(s):
+Prior GitHub username(s) or other submission aliases, if any:
+Authorized contribution scope (repositories, projects, or roles):
+Covered period/start date (identify any earlier Contributions included):
+
+I am authorized to bind the Entity identified above, and the Entity agrees to
+the Albucore CLA Version 1.0 (July 14, 2026).
+```
+
+An individual contributor must use the Individual statement unless a completed
+Entity Acceptance Record already covers that contributor and Contribution.

--- a/legal/cla/archive/MANIFEST.md
+++ b/legal/cla/archive/MANIFEST.md
@@ -1,0 +1,28 @@
+# Albucore CLA Archive Manifest
+
+This manifest identifies the exact public agreement text presented by CLA
+Assistant. Signer records and entity acceptance records are stored separately
+and are not part of this repository.
+
+## Version 1.0
+
+- Agreement: Albucore Contributor License Agreement Version 1.0
+- Date: July 14, 2026
+- Archive path: `legal/cla/archive/CLA-v1.0-2026-07-14.md`
+- Repository archive: [`CLA-v1.0-2026-07-14.md`](CLA-v1.0-2026-07-14.md)
+- CLA SHA-256: `1543cc0df9dc3184a5428cff3539247769fd5e3ae4e65b276c4c63815442c2dc`
+- CLA byte length: `15805`
+- Hosted Gist: `https://gist.github.com/ternaus/8c80c573845e5453fb4ddb8dc23b442d`
+- Immutable Gist revision: `4be4e1aaed8363e1413fcc9c82dc70da71b784ce`
+- Immutable revision URL: `https://gist.github.com/ternaus/8c80c573845e5453fb4ddb8dc23b442d/4be4e1aaed8363e1413fcc9c82dc70da71b784ce`
+- Gist `CLA.md` SHA-256: `1543cc0df9dc3184a5428cff3539247769fd5e3ae4e65b276c4c63815442c2dc`
+- Gist `CLA.md` byte length: `15805`
+- Gist `metadata` SHA-256: `0a15f455a0489b677b9681cb648219ba8090a587ee7d9c127ccdf38c5eff654a`
+- Gist `metadata` byte length: `604`
+
+The repository archive and the Gist's `CLA.md` file are byte-identical. The
+individual acceptance statement for this version is:
+
+```text
+I have read and agree to the Albucore CLA Version 1.0 (July 14, 2026) as an individual.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ version = "0.2.4"
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"
 keywords = [ "deep learning", "image processing" ]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 maintainers = [ { name = "Vladimir Iglovikov" } ]
 
 authors = [ { name = "Vladimir Iglovikov" } ]
@@ -53,7 +54,25 @@ packages = ["albucore"]
 include = ["albucore/py.typed"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["tests/**", "benchmarks/**", "benchmark/**", "conda.recipe/**"]
+exclude = [
+  "CLA.md",
+  "legal/**",
+  "_internal/**",
+  "private/**",
+  "data/private/**",
+  "**/*signature*",
+  "**/*signer*",
+  "**/*acceptance*record*/**",
+  "**/*entity*acceptance*/**",
+  "**/*cla*assistant*/**",
+  "dist/**",
+  "**/*.whl",
+  "**/*.tar.gz",
+  "tests/**",
+  "benchmarks/**",
+  "benchmark/**",
+  "conda.recipe/**",
+]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/tests/test_legal_integrity.py
+++ b/tests/test_legal_integrity.py
@@ -1,0 +1,250 @@
+"""Tests for Albucore license, CLA, and artifact integrity."""
+
+from __future__ import annotations
+
+import io
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+from tools import verify_legal_integrity as legal_integrity
+from tools.verify_legal_integrity import (
+    CLA_ARCHIVE_PATH,
+    REPO_ROOT,
+    REQUIRED_SOURCE_FILES,
+    collect_artifact_errors,
+    collect_source_errors,
+    main,
+)
+
+
+def _distribution_metadata(
+    *,
+    license_expression: str = "MIT",
+    license_files: tuple[str, ...] = ("LICENSE",),
+) -> bytes:
+    lines = [
+        "Metadata-Version: 2.4",
+        "Name: albucore",
+        "Version: 0.2.4",
+        f"License-Expression: {license_expression}",
+        *(f"License-File: {relative_path}" for relative_path in license_files),
+        "",
+    ]
+    return "\n".join(lines).encode()
+
+
+def _write_wheel(
+    path: Path,
+    *,
+    license_bytes: bytes | None = None,
+    metadata: bytes | None = None,
+    extra_files: dict[str, bytes] | None = None,
+) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "albucore-0.2.4.dist-info/licenses/LICENSE",
+            license_bytes if license_bytes is not None else (REPO_ROOT / "LICENSE").read_bytes(),
+        )
+        archive.writestr("albucore-0.2.4.dist-info/METADATA", metadata or _distribution_metadata())
+        for relative_path, content in (extra_files or {}).items():
+            archive.writestr(relative_path, content)
+
+
+def _write_sdist(
+    path: Path,
+    *,
+    license_bytes: bytes | None = None,
+    metadata: bytes | None = None,
+    extra_files: dict[str, bytes] | None = None,
+) -> None:
+    root = "albucore-0.2.4"
+    files = {
+        "LICENSE": license_bytes if license_bytes is not None else (REPO_ROOT / "LICENSE").read_bytes(),
+        "PKG-INFO": metadata or _distribution_metadata(),
+        **(extra_files or {}),
+    }
+    with tarfile.open(path, "w:gz") as archive:
+        for relative_path, content in files.items():
+            info = tarfile.TarInfo(f"{root}/{relative_path}")
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+
+
+def _copy_source_inputs(destination: Path) -> None:
+    for relative_path in REQUIRED_SOURCE_FILES:
+        source = REPO_ROOT / relative_path
+        target = destination / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+
+
+def test_source_legal_integrity() -> None:
+    assert collect_source_errors() == []
+
+
+def test_source_legal_integrity_with_windows_default_encoding(monkeypatch) -> None:
+    original_read_text = Path.read_text
+
+    def read_text_with_windows_default(
+        path: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
+        return original_read_text(path, encoding=encoding or "cp1252", errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", read_text_with_windows_default)
+
+    assert collect_source_errors() == []
+
+
+def test_cli_reports_missing_required_file_without_artifacts(tmp_path, monkeypatch, capsys) -> None:
+    missing_file = "LICENSE"
+    for relative_path in REQUIRED_SOURCE_FILES:
+        if relative_path == missing_file:
+            continue
+        target = tmp_path / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"placeholder")
+
+    monkeypatch.setattr(legal_integrity, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["verify_legal_integrity.py"])
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"ERROR: missing required legal-integrity file: {missing_file}\n"
+
+
+def test_source_rejects_root_and_archive_cla_mismatch(tmp_path) -> None:
+    _copy_source_inputs(tmp_path)
+    (tmp_path / CLA_ARCHIVE_PATH).write_text("changed archived agreement\n")
+
+    errors = collect_source_errors(tmp_path)
+
+    assert "root CLA.md is not byte-identical to the archived Version 1.0 text" in errors
+
+
+def test_source_rejects_private_signer_export_anywhere_in_repository(tmp_path) -> None:
+    _copy_source_inputs(tmp_path)
+    (tmp_path / "signatures.json").write_text('{"signatures": []}\n')
+
+    errors = collect_source_errors(tmp_path)
+
+    assert "private CLA acceptance material must not be committed: signatures.json" in errors
+
+
+def test_source_rejects_private_acceptance_directories_with_underscores(tmp_path) -> None:
+    _copy_source_inputs(tmp_path)
+    entity_record = tmp_path / "entity_acceptance" / "acme-corp.eml"
+    entity_record.parent.mkdir()
+    entity_record.write_text("synthetic entity acceptance\n")
+    assistant_export = tmp_path / "cla_assistant" / "export.json"
+    assistant_export.parent.mkdir()
+    assistant_export.write_text('{"signatures": []}\n')
+
+    errors = collect_source_errors(tmp_path)
+
+    assert "private CLA acceptance material must not be committed: entity_acceptance/acme-corp.eml" in errors
+    assert "private CLA acceptance material must not be committed: cla_assistant/export.json" in errors
+
+
+def test_wheel_and_sdist_accept_mit_metadata_and_exact_license(tmp_path) -> None:
+    wheel = tmp_path / "albucore-0.2.4-py3-none-any.whl"
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_wheel(wheel)
+    _write_sdist(sdist)
+
+    assert collect_artifact_errors(wheel, (REPO_ROOT / "LICENSE").read_bytes()) == []
+    assert collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes()) == []
+
+
+def test_artifact_rejects_wrong_license_expression(tmp_path) -> None:
+    wheel = tmp_path / "albucore-0.2.4-py3-none-any.whl"
+    _write_wheel(wheel, metadata=_distribution_metadata(license_expression="BSD-3-Clause"))
+
+    errors = collect_artifact_errors(wheel, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [f"{wheel.name}: wheel METADATA License-Expression must be 'MIT', found 'BSD-3-Clause'"]
+
+
+def test_artifact_rejects_changed_license_bytes(tmp_path) -> None:
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_sdist(sdist, license_bytes=b"changed license")
+
+    errors = collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [f"{sdist.name}: LICENSE is not byte-identical to the source file"]
+
+
+def test_artifact_rejects_cla_and_archive(tmp_path) -> None:
+    wheel = tmp_path / "albucore-0.2.4-py3-none-any.whl"
+    _write_wheel(
+        wheel,
+        extra_files={
+            "CLA.md": b"inbound agreement",
+            "legal/cla/archive/CLA-v1.0-2026-07-14.md": b"inbound agreement",
+        },
+    )
+
+    errors = collect_artifact_errors(wheel, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [
+        f"{wheel.name}: inbound CLA material leaked into artifact as CLA.md",
+        f"{wheel.name}: inbound CLA material leaked into artifact as legal/cla/archive/CLA-v1.0-2026-07-14.md",
+    ]
+
+
+def test_artifact_rejects_internal_material(tmp_path) -> None:
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_sdist(sdist, extra_files={"_internal/private-plan.md": b"private"})
+
+    errors = collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [
+        f"{sdist.name}: private _internal material leaked into artifact as albucore-0.2.4/_internal/private-plan.md",
+    ]
+
+
+def test_artifact_rejects_private_signer_export(tmp_path) -> None:
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_sdist(sdist, extra_files={"signatures.json": b'{"signatures": []}'})
+
+    errors = collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [
+        f"{sdist.name}: private CLA acceptance material leaked into artifact as albucore-0.2.4/signatures.json",
+    ]
+
+
+def test_artifact_rejects_private_acceptance_directories_with_underscores(tmp_path) -> None:
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_sdist(
+        sdist,
+        extra_files={
+            "entity_acceptance/acme-corp.eml": b"synthetic entity acceptance",
+            "cla_assistant/export.json": b'{"signatures": []}',
+        },
+    )
+
+    errors = collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [
+        f"{sdist.name}: private CLA acceptance material leaked into artifact as "
+        "albucore-0.2.4/entity_acceptance/acme-corp.eml",
+        f"{sdist.name}: private CLA acceptance material leaked into artifact as "
+        "albucore-0.2.4/cla_assistant/export.json",
+    ]
+
+
+def test_sdist_rejects_nested_distribution_artifact(tmp_path) -> None:
+    sdist = tmp_path / "albucore-0.2.4.tar.gz"
+    _write_sdist(sdist, extra_files={"unexpected/albucore-0.2.3-py3-none-any.whl": b"old wheel"})
+
+    errors = collect_artifact_errors(sdist, (REPO_ROOT / "LICENSE").read_bytes())
+
+    assert errors == [
+        f"{sdist.name}: nested distribution artifact leaked into sdist as "
+        "albucore-0.2.4/unexpected/albucore-0.2.3-py3-none-any.whl",
+    ]

--- a/tests/test_legal_integrity.py
+++ b/tests/test_legal_integrity.py
@@ -99,6 +99,18 @@ def test_source_legal_integrity_with_windows_default_encoding(monkeypatch) -> No
     assert collect_source_errors() == []
 
 
+def test_pre_commit_legal_integrity_hook_always_runs() -> None:
+    config_lines = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8").splitlines()
+    hook_start = config_lines.index("      - id: check-legal-integrity")
+    hook_lines: list[str] = []
+    for line in config_lines[hook_start + 1 :]:
+        if not line.startswith("        "):
+            break
+        hook_lines.append(line)
+
+    assert "        always_run: true" in hook_lines
+
+
 def test_cli_reports_missing_required_file_without_artifacts(tmp_path, monkeypatch, capsys) -> None:
     missing_file = "LICENSE"
     for relative_path in REQUIRED_SOURCE_FILES:

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import urllib.error
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -67,6 +68,45 @@ def test_ci_matrix_missing_workflow_error_is_not_duplicated(monkeypatch) -> None
     errors = ci_matrix.check()
 
     assert errors.count(f"Required workflow {missing_workflow.relative_to(ci_matrix.REPO_ROOT)} is missing") == 1
+
+
+def test_ci_matrix_requires_legal_artifact_verifier_commands(monkeypatch) -> None:
+    release_candidate_text = ci_matrix.RELEASE_CANDIDATE_WORKFLOW.read_text().replace(
+        ci_matrix.LEGAL_ARTIFACT_VERIFY_COMMAND,
+        "",
+    )
+    publish_text = ci_matrix.PUBLISH_WORKFLOW.read_text().replace(ci_matrix.LEGAL_ARTIFACT_VERIFY_COMMAND, "")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.RELEASE_CANDIDATE_WORKFLOW:
+            return release_candidate_text
+        if path == ci_matrix.PUBLISH_WORKFLOW:
+            return publish_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert ".github/workflows/release-candidate.yml is missing legal artifact verifier" in errors
+    assert ".github/workflows/publish.yml is missing legal artifact verifier" in errors
+
+
+def test_ci_matrix_requires_legal_artifact_verifier_in_both_publish_paths(monkeypatch) -> None:
+    publish_text = ci_matrix.PUBLISH_WORKFLOW.read_text().replace(ci_matrix.LEGAL_ARTIFACT_VERIFY_COMMAND, "", 1)
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.PUBLISH_WORKFLOW:
+            return publish_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert ".github/workflows/publish.yml must run the legal artifact verifier in both publish paths" in errors
 
 
 def test_benchmark_regression_check_blocks_release(tmp_path, monkeypatch) -> None:

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -17,12 +17,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 BENCHMARK_PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "benchmark-pr.yml"
+LEGAL_INTEGRITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "legal-integrity.yml"
 PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 RELEASE_CANDIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-candidate.yml"
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 SUPPORT_POLICY = REPO_ROOT / "docs" / "maintaining" / "support-policy.md"
 VALIDATE_RELEASE_CANDIDATE_TOOL = REPO_ROOT / "tools" / "validate_release_candidate.py"
 VERIFY_PUBLISH_ARTIFACTS_TOOL = REPO_ROOT / "tools" / "verify_publish_artifacts.py"
+LEGAL_ARTIFACT_VERIFY_COMMAND = "python tools/verify_legal_integrity.py --artifacts dist/*.whl dist/*.tar.gz"
 
 
 def _load_pyproject() -> dict[str, Any]:
@@ -129,6 +131,25 @@ def _check_release_workflows(errors: list[str]) -> None:
     )
     _check_file_fragments(
         errors,
+        LEGAL_INTEGRITY_WORKFLOW,
+        {
+            "pull request trigger": "pull_request:",
+            "manual trigger": "workflow_dispatch:",
+            "minimal contents permission": "contents: read",
+            "legal integrity job": "License, CLA, and package notices",
+            "source-tree verifier step": "Verify source-tree legal integrity",
+            "source-tree legal verifier": "python tools/verify_legal_integrity.py",
+            "legal verifier tests": "tests/test_legal_integrity.py",
+            "distribution build": 'uv build --out-dir "${RUNNER_TEMP}/albucore-legal-dist"',
+            "artifact verifier step": "Verify distribution license and CLA exclusion",
+            "distribution legal verifier": "python tools/verify_legal_integrity.py --artifacts",
+            "wheel verification": "albucore-legal-dist/*.whl",
+            "source distribution verification": "albucore-legal-dist/*.tar.gz",
+            "distribution metadata check": 'twine check "${RUNNER_TEMP}"/albucore-legal-dist/*',
+        },
+    )
+    _check_file_fragments(
+        errors,
         RELEASE_CANDIDATE_WORKFLOW,
         {
             "manual release candidate trigger": "workflow_dispatch:",
@@ -139,6 +160,7 @@ def _check_release_workflows(errors: list[str]) -> None:
             "release validation headless extra": "uv sync --frozen --extra headless --group dev",
             "project-free runtime dependency export": "uv export --frozen --no-dev --no-emit-project",
             "candidate metadata writer": "tools/validate_release_candidate.py candidate-metadata",
+            "legal artifact verifier": LEGAL_ARTIFACT_VERIFY_COMMAND,
             "release candidate artifact upload": "release-candidate-artifacts",
         },
     )
@@ -163,6 +185,7 @@ def _check_release_workflows(errors: list[str]) -> None:
             "manual publish trigger": "workflow_dispatch:",
             "candidate run input": "candidate_run_id:",
             "candidate artifact download": "release-candidate-artifacts",
+            "legal artifact verifier": LEGAL_ARTIFACT_VERIFY_COMMAND,
             "prepublish verifier": "tools/verify_publish_artifacts.py prepublish",
             "direct release verifier": "tools/verify_publish_artifacts.py direct-release",
             "PyPI distribution staging": "tools/verify_publish_artifacts.py prepare-pypi-dist",
@@ -172,6 +195,10 @@ def _check_release_workflows(errors: list[str]) -> None:
             "GitHub Release only after PyPI": "Create or update GitHub Release",
         },
     )
+    if PUBLISH_WORKFLOW.exists() and PUBLISH_WORKFLOW.read_text().count(LEGAL_ARTIFACT_VERIFY_COMMAND) == 1:
+        errors.append(
+            f"{PUBLISH_WORKFLOW.relative_to(REPO_ROOT)} must run the legal artifact verifier in both publish paths",
+        )
     _check_file_absent_fragments(
         errors,
         PUBLISH_WORKFLOW,

--- a/tools/verify_legal_integrity.py
+++ b/tools/verify_legal_integrity.py
@@ -1,0 +1,410 @@
+"""Verify Albucore's MIT license, CLA archive, and distribution artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import tarfile
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 uses the project dependency
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SPDX_LICENSE = "MIT"
+MIT_LICENSE_SHA256 = "645b7bab67908fe69ff10077947e6459d3e03d3cb21939e08c95592d0e9e3516"
+CLA_V1_SHA256 = "1543cc0df9dc3184a5428cff3539247769fd5e3ae4e65b276c4c63815442c2dc"
+CLA_ARCHIVE_PATH = "legal/cla/archive/CLA-v1.0-2026-07-14.md"
+CLA_MANIFEST_PATH = "legal/cla/archive/MANIFEST.md"
+CLA_GIST_URL = "https://gist.github.com/ternaus/8c80c573845e5453fb4ddb8dc23b442d"
+CLA_GIST_REVISION = "4be4e1aaed8363e1413fcc9c82dc70da71b784ce"
+CLA_GIST_METADATA_SHA256 = "0a15f455a0489b677b9681cb648219ba8090a587ee7d9c127ccdf38c5eff654a"
+
+PRIVATE_ACCEPTANCE_MARKERS = (
+    "signature",
+    "signer",
+    "acceptance-record",
+    "entity-acceptance",
+    "cla-assistant",
+)
+PRIVATE_ACCEPTANCE_DIRECTORIES = {
+    "private",
+    "-private",
+    "signatures",
+    "signers",
+    "acceptance-records",
+    "entity-acceptances",
+    "cla-assistant-exports",
+}
+SOURCE_SCAN_EXCLUDED_DIRECTORIES = {
+    ".git",
+    ".mypy-cache",
+    ".pytest-cache",
+    ".ruff-cache",
+    ".tox",
+    ".venv",
+    "--pycache--",
+    "build",
+    "dist",
+}
+
+REQUIRED_SOURCE_FILES = (
+    "LICENSE",
+    "CLA.md",
+    CLA_ARCHIVE_PATH,
+    CLA_MANIFEST_PATH,
+    "CONTRIBUTING.md",
+    "README.md",
+    "docs/maintaining/license-provenance.md",
+    "pyproject.toml",
+)
+
+
+def sha256(data: bytes) -> str:
+    """Return the lowercase SHA-256 digest for data."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _normalized_exclude(exclude: str) -> str:
+    return exclude.replace("\\", "/").strip("/").removesuffix("/**").rstrip("/")
+
+
+def _check_project_metadata(repo_root: Path) -> list[str]:
+    pyproject_path = repo_root / "pyproject.toml"
+    try:
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        return [f"pyproject.toml is not valid TOML: {exc}"]
+
+    project = pyproject.get("project", {})
+    errors: list[str] = []
+    if project.get("license") != SPDX_LICENSE:
+        errors.append(f"pyproject project.license must be {SPDX_LICENSE!r}")
+
+    if project.get("license-files") != ["LICENSE"]:
+        errors.append("pyproject project.license-files must be exactly ['LICENSE']")
+
+    classifiers = project.get("classifiers", [])
+    if "License :: OSI Approved :: MIT License" not in classifiers:
+        errors.append("pyproject classifiers must include the MIT License classifier")
+
+    hatch_build = pyproject.get("tool", {}).get("hatch", {}).get("build", {})
+    configured_exclude_values = [
+        *hatch_build.get("exclude", []),
+        *hatch_build.get("targets", {}).get("sdist", {}).get("exclude", []),
+    ]
+    configured_excludes = {_normalized_exclude(value) for value in configured_exclude_values if isinstance(value, str)}
+    required_excludes = (
+        "CLA.md",
+        "legal",
+        "_internal",
+        "private",
+        "data/private",
+        "**/*signature*",
+        "**/*signer*",
+        "**/*acceptance*record*",
+        "**/*entity*acceptance*",
+        "**/*cla*assistant*",
+    )
+    errors.extend(
+        f"pyproject hatch build exclusions must contain {required_exclude!r}"
+        for required_exclude in required_excludes
+        if required_exclude not in configured_excludes
+    )
+    return errors
+
+
+def _check_license(repo_root: Path) -> list[str]:
+    if sha256((repo_root / "LICENSE").read_bytes()) != MIT_LICENSE_SHA256:
+        return ["LICENSE does not match the reviewed MIT text"]
+    return []
+
+
+def _check_cla_archive(repo_root: Path) -> list[str]:
+    root_cla = (repo_root / "CLA.md").read_bytes()
+    archived_cla = (repo_root / CLA_ARCHIVE_PATH).read_bytes()
+    errors: list[str] = []
+
+    if sha256(root_cla) != CLA_V1_SHA256:
+        errors.append("root CLA.md does not match its immutable Version 1.0 SHA-256 identifier")
+    if sha256(archived_cla) != CLA_V1_SHA256:
+        errors.append("archived CLA Version 1.0 does not match its immutable SHA-256 identifier")
+    if root_cla != archived_cla:
+        errors.append("root CLA.md is not byte-identical to the archived Version 1.0 text")
+
+    archive_dir = repo_root / "legal/cla/archive"
+    archived_versions = {
+        path.relative_to(repo_root).as_posix() for path in archive_dir.glob("CLA-v*.md") if path.is_file()
+    }
+    if archived_versions != {CLA_ARCHIVE_PATH}:
+        unexpected = sorted(archived_versions - {CLA_ARCHIVE_PATH})
+        missing = sorted({CLA_ARCHIVE_PATH} - archived_versions)
+        if unexpected:
+            errors.append(f"unregistered CLA archive files found: {', '.join(unexpected)}")
+        if missing:
+            errors.append(f"registered CLA archive files are missing: {', '.join(missing)}")
+
+    manifest = (repo_root / CLA_MANIFEST_PATH).read_text(encoding="utf-8")
+    required_manifest_values = (
+        CLA_ARCHIVE_PATH,
+        CLA_V1_SHA256,
+        CLA_GIST_URL,
+        CLA_GIST_REVISION,
+        CLA_GIST_METADATA_SHA256,
+        "Version 1.0",
+        "July 14, 2026",
+    )
+    errors.extend(
+        f"CLA manifest is missing {required_value!r}"
+        for required_value in required_manifest_values
+        if required_value not in manifest
+    )
+
+    normalized_cla = " ".join(root_cla.decode("utf-8").split())
+    required_cla_phrases = (
+        "Albumentations, LLC",
+        "license or sublicense it under open-source, source-available, commercial, proprietary, or other terms",
+        "first or simultaneously make the accepted version of that Covered Contribution available",
+        "I have read and agree to the Albucore CLA Version 1.0 (July 14, 2026) as an individual.",
+    )
+    errors.extend(
+        f"CLA Version 1.0 is missing {required_phrase!r}"
+        for required_phrase in required_cla_phrases
+        if required_phrase not in normalized_cla
+    )
+    return errors
+
+
+def _check_public_copy(repo_root: Path) -> list[str]:
+    contributing = " ".join((repo_root / "CONTRIBUTING.md").read_text(encoding="utf-8").split())
+    required_contributing_phrases = (
+        "Albucore remains publicly available under the [MIT License](LICENSE)",
+        "does not change the repository's license",
+        "Version 1.0 Acceptance Record",
+    )
+    errors = [
+        f"CONTRIBUTING.md is missing {required_phrase!r}"
+        for required_phrase in required_contributing_phrases
+        if required_phrase not in contributing
+    ]
+
+    readme = " ".join((repo_root / "README.md").read_text(encoding="utf-8").split())
+    if "License-MIT" not in readme:
+        errors.append("README.md must identify the public project license as MIT")
+
+    provenance = " ".join(
+        (repo_root / "docs/maintaining/license-provenance.md").read_text(encoding="utf-8").split(),
+    )
+    required_provenance_phrases = (
+        "The CLA does not replace or narrow MIT permissions",
+        "Do not commit them to this repository or include them in release artifacts",
+        "License, CLA, and package notices",
+    )
+    errors.extend(
+        f"license-provenance.md is missing {required_phrase!r}"
+        for required_phrase in required_provenance_phrases
+        if required_phrase not in provenance
+    )
+    return errors
+
+
+def _normalized_path_part(part: str) -> str:
+    return part.lower().replace("_", "-").replace(" ", "-")
+
+
+def _is_private_acceptance_path(path: PurePosixPath) -> bool:
+    normalized_parts = tuple(_normalized_path_part(part) for part in path.parts)
+    if any(part in PRIVATE_ACCEPTANCE_DIRECTORIES for part in normalized_parts):
+        return True
+    return any(marker in part for part in normalized_parts for marker in PRIVATE_ACCEPTANCE_MARKERS)
+
+
+def _check_private_acceptance_records(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(repo_root)
+        normalized_parts = {_normalized_path_part(part) for part in relative_path.parts[:-1]}
+        if normalized_parts & SOURCE_SCAN_EXCLUDED_DIRECTORIES:
+            continue
+        relative_posix_path = PurePosixPath(relative_path.as_posix())
+        if _is_private_acceptance_path(relative_posix_path):
+            errors.append(f"private CLA acceptance material must not be committed: {relative_posix_path}")
+    return errors
+
+
+def collect_source_errors(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Collect all source-tree legal-integrity violations."""
+    errors = [
+        f"missing required legal-integrity file: {relative_path}"
+        for relative_path in REQUIRED_SOURCE_FILES
+        if not (repo_root / relative_path).is_file()
+    ]
+    if errors:
+        return errors
+
+    errors.extend(_check_project_metadata(repo_root))
+    errors.extend(_check_license(repo_root))
+    errors.extend(_check_cla_archive(repo_root))
+    errors.extend(_check_public_copy(repo_root))
+    errors.extend(_check_private_acceptance_records(repo_root))
+    return errors
+
+
+def _zip_members(artifact: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(artifact) as archive:
+        return {name: archive.read(name) for name in archive.namelist() if not name.endswith("/")}
+
+
+def _tar_members(artifact: Path) -> dict[str, bytes]:
+    members: dict[str, bytes] = {}
+    with tarfile.open(artifact, "r:*") as archive:
+        for member in archive.getmembers():
+            if not member.isfile():
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is not None:
+                members[member.name] = extracted.read()
+    return members
+
+
+def read_artifact_members(artifact: Path) -> dict[str, bytes]:
+    """Read regular files from a wheel, zip file, or source tarball."""
+    if zipfile.is_zipfile(artifact):
+        return _zip_members(artifact)
+    if tarfile.is_tarfile(artifact):
+        return _tar_members(artifact)
+    raise ValueError(f"unsupported distribution artifact: {artifact}")
+
+
+def _metadata_errors(artifact: Path, metadata: bytes, label: str) -> list[str]:
+    message = BytesParser().parsebytes(metadata, headersonly=True)
+    errors: list[str] = []
+
+    license_expressions = message.get_all("License-Expression", [])
+    if license_expressions != [SPDX_LICENSE]:
+        expression_summary = ", ".join(license_expressions) if license_expressions else "missing"
+        errors.append(
+            f"{artifact.name}: {label} License-Expression must be {SPDX_LICENSE!r}, found {expression_summary!r}",
+        )
+
+    license_files = message.get_all("License-File", [])
+    if license_files != ["LICENSE"]:
+        file_summary = ", ".join(license_files) if license_files else "missing"
+        errors.append(f"{artifact.name}: {label} License-File must be exactly 'LICENSE', found {file_summary!r}")
+    return errors
+
+
+def _wheel_metadata_errors(artifact: Path, members: Mapping[str, bytes]) -> list[str]:
+    metadata_members = [
+        name
+        for name in members
+        if PurePosixPath(name).name == "METADATA" and PurePosixPath(name).parent.name.endswith(".dist-info")
+    ]
+    if len(metadata_members) != 1:
+        return [f"{artifact.name}: expected exactly one wheel .dist-info/METADATA file, found {len(metadata_members)}"]
+    return _metadata_errors(artifact, members[metadata_members[0]], "wheel METADATA")
+
+
+def _sdist_metadata_errors(artifact: Path, members: Mapping[str, bytes]) -> list[str]:
+    metadata_members = [
+        name for name in members if PurePosixPath(name).name == "PKG-INFO" and len(PurePosixPath(name).parts) == 2
+    ]
+    if len(metadata_members) != 1:
+        return [f"{artifact.name}: expected exactly one root sdist PKG-INFO file, found {len(metadata_members)}"]
+    return _metadata_errors(artifact, members[metadata_members[0]], "sdist PKG-INFO")
+
+
+def _contains_contiguous_parts(path: PurePosixPath, expected_parts: tuple[str, ...]) -> bool:
+    path_parts = path.parts
+    expected_length = len(expected_parts)
+    return any(
+        path_parts[index : index + expected_length] == expected_parts
+        for index in range(len(path_parts) - expected_length + 1)
+    )
+
+
+def _forbidden_artifact_errors(artifact: Path, members: Mapping[str, bytes]) -> list[str]:
+    errors: list[str] = []
+    for member_name in members:
+        member_path = PurePosixPath(member_name)
+        if member_path.name == "CLA.md" or _contains_contiguous_parts(member_path, ("legal", "cla")):
+            errors.append(f"{artifact.name}: inbound CLA material leaked into artifact as {member_name}")
+        if "_internal" in member_path.parts:
+            errors.append(f"{artifact.name}: private _internal material leaked into artifact as {member_name}")
+        if _is_private_acceptance_path(member_path):
+            errors.append(f"{artifact.name}: private CLA acceptance material leaked into artifact as {member_name}")
+        if artifact.suffix != ".whl" and member_name.endswith((".whl", ".tar.gz")):
+            errors.append(f"{artifact.name}: nested distribution artifact leaked into sdist as {member_name}")
+    return errors
+
+
+def collect_artifact_errors(artifact: Path, expected_license: bytes) -> list[str]:
+    """Collect package metadata, license-content, and inbound-material errors."""
+    members = read_artifact_members(artifact)
+    if artifact.suffix == ".whl":
+        errors = _wheel_metadata_errors(artifact, members)
+    else:
+        errors = _sdist_metadata_errors(artifact, members)
+
+    license_members = [name for name in members if PurePosixPath(name).name == "LICENSE"]
+    if len(license_members) != 1:
+        errors.append(f"{artifact.name}: expected exactly one LICENSE file, found {len(license_members)}")
+    elif members[license_members[0]] != expected_license:
+        errors.append(f"{artifact.name}: LICENSE is not byte-identical to the source file")
+
+    errors.extend(_forbidden_artifact_errors(artifact, members))
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts",
+        nargs="*",
+        type=Path,
+        default=(),
+        help="Built wheel and sdist paths to verify after the source-tree checks.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run source and optional artifact checks."""
+    args = parse_args()
+    errors = collect_source_errors(REPO_ROOT)
+    if not errors and args.artifacts:
+        expected_license = (REPO_ROOT / "LICENSE").read_bytes()
+        for artifact in args.artifacts:
+            if not artifact.is_file():
+                errors.append(f"artifact does not exist: {artifact}")
+                continue
+            try:
+                errors.extend(collect_artifact_errors(artifact, expected_license))
+            except (OSError, tarfile.TarError, ValueError, zipfile.BadZipFile) as exc:
+                errors.append(f"{artifact.name}: could not inspect artifact: {exc}")
+
+    if errors:
+        for error in errors:
+            sys.stderr.write(f"ERROR: {error}\n")
+        return 1
+
+    artifact_count = len(args.artifacts)
+    sys.stdout.write(f"Legal integrity verified: source tree and {artifact_count} artifact(s).\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- keep Albucore publicly licensed under MIT without changing historical MIT permissions
- add a separate Albucore Contributor License Agreement Version 1.0 for future contribution governance
- archive the exact CLA text with SHA-256, byte length, and immutable hosted-Gist provenance
- document individual and entity acceptance paths
- switch package metadata to PEP 639 `License-Expression: MIT`
- add source, wheel, sdist, release, publish, and CI integrity gates
- prevent CLA text, internal material, signer exports, and entity acceptance records from entering package artifacts

## Hosted configuration

- separate secret/unlisted Gist: `8c80c573845e5453fb4ddb8dc23b442d`
- immutable revision: `4be4e1aaed8363e1413fcc9c82dc70da71b784ce`
- CLA Assistant linked at repository level
- shared signatures across repositories: disabled
- end-to-end `license/cla` status: passed on this PR
- active `Protect main` ruleset requires both `license/cla` and `License, CLA, and package notices`

## Validation

- `1721 passed`
- full pre-commit suite passed
- staged-only `pre-commit run check-legal-integrity --files signatures.json` invoked the repository-wide legal scanner
- source legal-integrity verifier passed
- CI topology verifier passed
- real wheel and sdist passed the legal-integrity verifier
- `twine check` passed for both artifacts
- synthetic `signatures.json`, `entity_acceptance/`, and `cla_assistant/` fixtures were blocked by the source verifier and confirmed absent from real sdists

Hosted CLA verification and the protected-branch merge gates are now configured and verified end to end.

## Summary by Sourcery

Introduce a formal Albucore Contributor License Agreement v1.0 and legal-integrity verification pipeline to protect MIT licensing and keep CLA records and private acceptance data out of release artifacts.

New Features:
- Add Albucore Contributor License Agreement v1.0 with documented individual and entity acceptance paths.
- Add a legal-integrity verification tool and GitHub workflow that enforce license, CLA, and packaging rules across source and built artifacts.

Enhancements:
- Update project metadata to use SPDX-style MIT license expression and explicit license file configuration.
- Extend CI release workflows to require legal-integrity checks for release candidates and publishes, including both publish paths.
- Document CLA governance, license provenance, and contributor process in new README, CONTRIBUTING, and maintaining guides.
- Tighten sdist build configuration to exclude CLA text, internal/private directories, acceptance records, and nested distribution artifacts.

Tests:
- Add a dedicated legal-integrity test suite covering source-tree validation, artifact metadata and content checks, and leakage of private acceptance material.
- Extend CI matrix tests to ensure legal artifact verifier commands are present in release-candidate and publish workflows and run in all publish paths.