### PR TITLE
Reject incomplete channel vectors in normalize

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,13 +58,13 @@ repos:
       - id: python-check-blanket-noqa
       - id: text-unicode-replacement-char
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.20
+    rev: v0.15.22
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -79,7 +79,7 @@ repos:
         args: [--py310-plus]
         exclude: ^(tests|benchmark)/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         files: ^(albucore|benchmark)/

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -257,6 +257,7 @@ def convert_value(value: np.ndarray | float, num_channels: int) -> float | np.nd
 
     Raises:
         TypeError: If value is of unsupported type
+        ValueError: If a channel vector has fewer values than the target image has channels
     """
     # Handle scalar types
     if isinstance(value, (float, int, np.float32, np.float64)):
@@ -273,7 +274,14 @@ def convert_value(value: np.ndarray | float, num_channels: int) -> float | np.nd
             return value
 
         # Handle 1D arrays
-        if len(value) == 1 or num_channels == 1 or len(value) < num_channels:
+        num_values = len(value)
+        if num_values == 1:
+            return float(value[0])
+
+        if num_values < num_channels:
+            raise ValueError(f"Expected a scalar or at least {num_channels} values, got {num_values}")
+
+        if num_channels == 1:
             return float(value[0])
 
         return value[:num_channels]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -184,6 +184,17 @@ def test_normalize_with_1d_arrays(dtype):
     np.testing.assert_allclose(result_3ch, expected_3ch, rtol=1e-5)
 
 
+@pytest.mark.parametrize("short_parameter", ["mean", "denominator"])
+def test_normalize_rejects_channel_parameter_with_fewer_values_than_channels(short_parameter: str) -> None:
+    img = np.zeros((5, 7, 3), dtype=np.uint8)
+    short_value = np.array([0.1, 0.2], dtype=np.float32)
+    mean = short_value if short_parameter == "mean" else np.ones(3, dtype=np.float32)
+    denominator = short_value if short_parameter == "denominator" else np.ones(3, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Expected a scalar or at least 3 values, got 2"):
+        normalize(img, mean, denominator)
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize("shape", [(100, 100, 1), (100, 100, 3)])
 def test_normalize_preserves_original_image(dtype, shape):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,12 @@ def test_convert_value(value, num_channels, expected):
     else:
         assert result == expected
 
+
+def test_convert_value_rejects_channel_vector_with_fewer_values_than_channels() -> None:
+    with pytest.raises(ValueError, match=r"Expected a scalar or at least 3 values, got 2"):
+        convert_value(np.array([1.5, 2.5], dtype=np.float32), num_channels=3)
+
+
 @contiguous
 def process_image(img: np.ndarray) -> np.ndarray:
     # For demonstration, let's just return a non-contiguous view


### PR DESCRIPTION
## Summary

- Raise `ValueError` when `convert_value` receives a non-scalar channel vector with fewer entries than the image has channels.
- Preserve scalar and one-element broadcasting, as well as the existing behavior for vectors that cover all channels.
- Update the pre-commit revisions for codespell, Ruff, and mypy.

## Root cause

`convert_value` treated every short one-dimensional array as a scalar and returned its first element. A standard normalization configured with too few `mean` or `std` values could therefore apply the first value to every channel and silently produce an incorrect result.

## User impact

Invalid per-channel normalization parameters now fail immediately instead of producing incorrectly normalized images.

## Validation

- `pre-commit run --all-files`
- `uv run pytest -q` — 1724 passed

## Summary by Sourcery

Tighten validation of per-channel normalization parameters so that incomplete channel vectors now fail fast with a clear error instead of being treated as scalars and silently misnormalizing images, while updating tooling versions in the pre-commit configuration.

New Features:
- Reject per-channel normalization parameters that provide fewer values than the target image has channels.

Bug Fixes:
- Prevent incorrect normalization caused by treating short per-channel vectors as scalars in convert_value.

Enhancements:
- Clarify convert_value error handling by documenting and enforcing ValueError for invalid channel vectors.

Build:
- Update pre-commit hook versions for codespell, Ruff, and mypy.

Tests:
- Add tests ensuring normalize and convert_value raise ValueError when channel vectors are shorter than the image channel count.