### PR TITLE
chore(release): bump to 0.2.5 and skip version-only tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,38 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  change_scope:
+    name: Classify change scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_tests: ${{ steps.classify.outputs.run_tests }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Classify version-only changes
+        id: classify
+        env:
+          BASE_REVISION: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python tools/classify_ci_changes.py
+          --repo .
+          "${BASE_REVISION}"
+          "${HEAD_REVISION}"
+          >> "${GITHUB_OUTPUT}"
+
   test:
+    needs: change_scope
+    if: needs.change_scope.outputs.run_tests == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -85,6 +116,8 @@ jobs:
           fail_ci_if_error: false
 
   declared-dependency-ranges:
+    needs: change_scope
+    if: needs.change_scope.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.4"
+version = "0.2.5"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/tests/test_ci_change_scope.py
+++ b/tests/test_ci_change_scope.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLASSIFIER = REPO_ROOT / "tools" / "classify_ci_changes.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_metadata(
+    repo: Path,
+    version: str,
+    numpy_requirement: str = "numpy>=1.24.4",
+    numpy_lock_version: str = "2.2.6",
+) -> None:
+    (repo / "pyproject.toml").write_text(
+        "\n".join(
+            (
+                "[project]",
+                'name = "albucore"',
+                f'version = "{version}"',
+                f'dependencies = ["{numpy_requirement}"]',
+                "",
+            ),
+        ),
+    )
+    (repo / "uv.lock").write_text(
+        "\n".join(
+            (
+                "version = 1",
+                "",
+                "[[package]]",
+                'name = "albucore"',
+                f'version = "{version}"',
+                'source = { editable = "." }',
+                'dependencies = [{ name = "numpy" }]',
+                "",
+                "[[package]]",
+                'name = "numpy"',
+                f'version = "{numpy_lock_version}"',
+                "",
+            ),
+        ),
+    )
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _version_change(repo: Path, old_version: str = "0.2.4", new_version: str = "0.2.5") -> tuple[str, str]:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    _git(repo, "config", "user.name", "CI Test")
+    _write_metadata(repo, old_version)
+    base = _commit(repo, "base")
+    _write_metadata(repo, new_version)
+    head = _commit(repo, "bump version")
+    return base, head
+
+
+def _classify(repo: Path, base: str, head: str) -> dict[str, str]:
+    result = subprocess.run(
+        [sys.executable, str(CLASSIFIER), "--repo", str(repo), base, head],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return dict(line.split("=", maxsplit=1) for line in result.stdout.splitlines())
+
+
+def test_version_only_change_skips_tests(tmp_path: Path) -> None:
+    base, head = _version_change(tmp_path)
+
+    assert _classify(tmp_path, base, head) == {"run_tests": "false"}
+
+
+def test_dependency_constraint_change_runs_tests(tmp_path: Path) -> None:
+    base, _ = _version_change(tmp_path)
+    _write_metadata(tmp_path, "0.2.5", numpy_requirement="numpy>=2.0")
+    head = _commit(tmp_path, "change dependency constraint")
+
+    assert _classify(tmp_path, base, head) == {"run_tests": "true"}
+
+
+def test_locked_dependency_change_runs_tests(tmp_path: Path) -> None:
+    base, _ = _version_change(tmp_path)
+    _write_metadata(tmp_path, "0.2.5", numpy_lock_version="2.3.0")
+    head = _commit(tmp_path, "change locked dependency")
+
+    assert _classify(tmp_path, base, head) == {"run_tests": "true"}
+
+
+def test_code_change_runs_tests(tmp_path: Path) -> None:
+    base, _ = _version_change(tmp_path)
+    (tmp_path / "albucore.py").write_text("VALUE = 1\n")
+    head = _commit(tmp_path, "change code")
+
+    assert _classify(tmp_path, base, head) == {"run_tests": "true"}

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -70,6 +70,27 @@ def test_ci_matrix_missing_workflow_error_is_not_duplicated(monkeypatch) -> None
     assert errors.count(f"Required workflow {missing_workflow.relative_to(ci_matrix.REPO_ROOT)} is missing") == 1
 
 
+def test_ci_matrix_requires_version_only_test_gating(monkeypatch) -> None:
+    ci_text = (
+        ci_matrix.CI_WORKFLOW.read_text()
+        .replace("python tools/classify_ci_changes.py", "")
+        .replace("if: needs.change_scope.outputs.run_tests == 'true'", "")
+    )
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CI_WORKFLOW:
+            return ci_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert "CI workflow is missing version-only change classifier" in errors
+    assert "CI workflow does not gate both test jobs on change scope" in errors
+
+
 def test_ci_matrix_requires_legal_artifact_verifier_commands(monkeypatch) -> None:
     release_candidate_text = ci_matrix.RELEASE_CANDIDATE_WORKFLOW.read_text().replace(
         ci_matrix.LEGAL_ARTIFACT_VERIFY_COMMAND,

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -80,6 +80,10 @@ def _check_ci(errors: list[str], versions: set[str]) -> None:
         errors.append("CI workflow is missing declared-dependency-ranges job")
     if "tools/check_router_contracts.py" not in text:
         errors.append("CI workflow does not run router contract check")
+    if "python tools/classify_ci_changes.py" not in text:
+        errors.append("CI workflow is missing version-only change classifier")
+    if text.count("if: needs.change_scope.outputs.run_tests == 'true'") != 2:
+        errors.append("CI workflow does not gate both test jobs on change scope")
     if "permissions:" not in text or "contents: read" not in text:
         errors.append("CI workflow must declare minimal GITHUB_TOKEN permissions")
 

--- a/tools/classify_ci_changes.py
+++ b/tools/classify_ci_changes.py
@@ -1,0 +1,108 @@
+"""Classify whether a commit range only changes Albucore package versions."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+VERSION_FILES: Final = frozenset({"pyproject.toml", "uv.lock"})
+PROJECT_NAME: Final = "albucore"
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    return subprocess.check_output(  # noqa: S603
+        ["git", "-C", str(repo), *args],  # noqa: S607
+        text=True,
+    ).strip()
+
+
+def _toml_at(repo: Path, revision: str, path: str) -> dict[str, Any]:
+    payload = tomllib.loads(_git_output(repo, "show", f"{revision}:{path}"))
+    if not isinstance(payload, dict):
+        msg = f"{path} at {revision} did not parse as a TOML table."
+        raise TypeError(msg)
+    return payload
+
+
+def _without_project_version(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        msg = "pyproject.toml is missing [project]."
+        raise TypeError(msg)
+
+    version = project.pop("version", None)
+    if not isinstance(version, str):
+        msg = "pyproject.toml project.version must be a string."
+        raise TypeError(msg)
+    return version, payload
+
+
+def _without_lock_version(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    packages = payload.get("package")
+    if not isinstance(packages, list):
+        msg = "uv.lock is missing a package list."
+        raise TypeError(msg)
+
+    matching_packages = [
+        package for package in packages if isinstance(package, dict) and package.get("name") == PROJECT_NAME
+    ]
+    if len(matching_packages) != 1:
+        msg = f"uv.lock must contain exactly one {PROJECT_NAME!r} package."
+        raise ValueError(msg)
+
+    version = matching_packages[0].pop("version", None)
+    if not isinstance(version, str):
+        msg = f"uv.lock package {PROJECT_NAME!r} version must be a string."
+        raise TypeError(msg)
+    return version, payload
+
+
+def is_version_only_change(repo: Path, base_revision: str, head_revision: str) -> bool:
+    """Return true only when both package metadata files change version and nothing else."""
+    try:
+        changed_files = set(_git_output(repo, "diff", "--name-only", base_revision, head_revision, "--").splitlines())
+        if changed_files != VERSION_FILES:
+            return False
+
+        base_project_version, base_project = _without_project_version(
+            _toml_at(repo, base_revision, "pyproject.toml"),
+        )
+        head_project_version, head_project = _without_project_version(
+            _toml_at(repo, head_revision, "pyproject.toml"),
+        )
+        base_lock_version, base_lock = _without_lock_version(_toml_at(repo, base_revision, "uv.lock"))
+        head_lock_version, head_lock = _without_lock_version(_toml_at(repo, head_revision, "uv.lock"))
+    except (subprocess.CalledProcessError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        return False
+
+    return (
+        base_project_version == base_lock_version
+        and head_project_version == head_lock_version
+        and base_project_version != head_project_version
+        and base_project == head_project
+        and base_lock == head_lock
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base_revision")
+    parser.add_argument("head_revision")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    version_only = is_version_only_change(args.repo, args.base_revision, args.head_revision)
+    sys.stdout.write(f"run_tests={str(not version_only).lower()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from `0.2.4` to `0.2.5`
- keep the editable package metadata in `uv.lock` synchronized
- classify PR and push diffs before allocating CI test runners
- skip the Python test matrix and declared-dependency-range tests only when the diff changes exactly the Albucore version fields in `pyproject.toml` and `uv.lock`
- keep full tests enabled for dependency, lockfile, code, malformed metadata, and mixed changes

The required legal-integrity workflow remains enabled because a version bump affects built package metadata and artifacts.

## Validation

- `uv lock --check`
- `uv run pytest` (1,729 passed)
- `pre-commit run --all-files`
- `uv run python tools/ci_matrix.py check`
- classifier integration tests for version-only, dependency-constraint, locked-dependency, and code changes

## Summary by Sourcery

Introduce CI change classification to skip Python test jobs for pure Albucore version-only bumps and bump package metadata to version 0.2.5.

Enhancements:
- Add a change_scope job and classifier script that detect version-only changes between revisions and expose a run_tests flag to downstream jobs.
- Gate main Python test matrix and declared-dependency-range jobs on the computed change scope so they only run when non-version changes are present.

Build:
- Update Albucore project and lockfile metadata to version 0.2.5.

CI:
- Extend the CI workflow with a change classification step and conditional execution of test jobs based on version-only detection.

Tests:
- Add tests for CI change classification behavior and for enforcing presence and gating of the classifier in the CI workflow.