### PR TITLE
fix(ci): diagnose missing CLA statuses

### DIFF
--- a/.github/workflows/cla-status.yml
+++ b/.github/workflows/cla-status.yml
@@ -1,0 +1,67 @@
+name: CLA Status Reporter
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number to inspect
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  cla-status:
+    name: CLA status reported
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Wait for hosted CLA status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+        run: |
+          if [[ -z "${HEAD_SHA}" ]]; then
+            HEAD_SHA="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+              --jq '.head.sha')"
+          fi
+
+          for attempt in {1..12}; do
+            cla_state="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/statuses" \
+              --jq 'map(select(.context == "license/cla")) | sort_by(.created_at) | reverse | .[0].state // ""')"
+
+            if [[ -n "${cla_state}" ]]; then
+              echo "CLA Assistant reported license/cla=${cla_state} for ${HEAD_SHA}."
+              exit 0
+            fi
+
+            if [[ "${attempt}" -lt 12 ]]; then
+              sleep 5
+            fi
+          done
+
+          recheck_url="https://cla-assistant.io/check/${GITHUB_REPOSITORY}?pullRequest=${PR_NUMBER}"
+          {
+            echo "## CLA Assistant did not report a status"
+            echo
+            echo "No \`license/cla\` commit status appeared for \`${HEAD_SHA}\` within one minute."
+            echo
+            echo "1. Open [CLA Assistant recheck](${recheck_url}) while signed in to GitHub."
+            echo "2. If the status is still absent, sign in at https://cla-assistant.io/ and run **Recheck PRs**."
+            echo "3. Follow the maintainer recovery procedure in \`docs/maintaining/license-provenance.md\`."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "::error title=CLA Assistant did not report license/cla::Open ${recheck_url}"
+          exit 1

--- a/.github/workflows/cla-status.yml
+++ b/.github/workflows/cla-status.yml
@@ -38,9 +38,9 @@ jobs:
           fi
 
           for attempt in {1..12}; do
-            cla_state="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/statuses" \
-              --jq 'map(select(.context == "license/cla")) | sort_by(.created_at) | reverse | .[0].state // ""')"
+            cla_state="$(gh api --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/statuses?per_page=100" |
+              jq -r 'add | map(select(.context == "license/cla")) | sort_by(.created_at) | reverse | .[0].state // ""')"
 
             if [[ -n "${cla_state}" ]]; then
               echo "CLA Assistant reported license/cla=${cla_state} for ${HEAD_SHA}."

--- a/docs/maintaining/license-provenance.md
+++ b/docs/maintaining/license-provenance.md
@@ -61,3 +61,47 @@ and archive, packaging exclusions for inbound/private material, and the absence
 of nested distribution artifacts. The `main` ruleset must require both hosted
 `license/cla` and the GitHub Actions check named
 `License, CLA, and package notices`.
+
+## Recover a missing `license/cla` status
+
+GitHub displays `Expected — Waiting for status to be reported` when the
+`license/cla` context does not exist on the pull request's current head commit.
+It does not mean that a GitHub Actions job is still running.
+
+The `CLA Status Reporter` workflow waits one minute for the hosted status. It
+reports success as soon as CLA Assistant creates `license/cla`, regardless of
+whether the contributor still needs to sign. It fails with a direct recovery
+link when the status is absent. The reporter has read-only status permissions:
+it cannot approve a contribution or replace the hosted CLA decision.
+
+For a missing status:
+
+1. Open
+   `https://cla-assistant.io/check/albumentations-team/albucore?pullRequest=NUMBER`
+   while signed in to GitHub.
+2. If the status remains absent, sign in at
+   [`cla-assistant.io`](https://cla-assistant.io/), open the Albucore repository
+   menu, and run **Recheck PRs**. Reauthorize GitHub if prompted.
+3. In GitHub repository settings, confirm that the CLA Assistant webhook is
+   active, subscribes to pull request events, and returned a successful response
+   for the pull request's latest `synchronize` or `opened` delivery.
+4. Confirm that `license/cla` now exists on the current head SHA:
+
+   ```bash
+   gh api \
+     repos/albumentations-team/albucore/commits/HEAD_SHA/statuses \
+     --jq '.[] | select(.context == "license/cla")'
+   ```
+
+Do not remove `license/cla` from the `main` ruleset to clear an outage. A
+maintainer may publish an emergency success status only after checking the
+durable Acceptance Record against every author and co-author in the pull
+request. Record the CLA version, covered GitHub identities, verification time,
+maintainer, and reason for the service-side override outside the public
+repository. The local legal-integrity workflow verifies agreement text and
+packaging; it does not verify who accepted the agreement.
+
+Once `CLA Status Reporter` has run successfully on the default branch, add its
+GitHub Actions check `CLA status reported` to the `main` ruleset and restrict
+that required check to GitHub Actions. Keep the hosted `license/cla` and
+`License, CLA, and package notices` requirements in place.

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -130,6 +130,23 @@ def test_ci_matrix_requires_legal_artifact_verifier_in_both_publish_paths(monkey
     assert ".github/workflows/publish.yml must run the legal artifact verifier in both publish paths" in errors
 
 
+def test_ci_matrix_rejects_cla_status_write_permission(monkeypatch) -> None:
+    cla_status_text = ci_matrix.CLA_STATUS_WORKFLOW.read_text().replace("statuses: read", "statuses: write")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CLA_STATUS_WORKFLOW:
+            return cla_status_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert ".github/workflows/cla-status.yml is missing read-only status permission" in errors
+    assert ".github/workflows/cla-status.yml must not contain status write permission" in errors
+
+
 def test_benchmark_regression_check_blocks_release(tmp_path, monkeypatch) -> None:
     baseline = tmp_path / "baseline.json"
     current = tmp_path / "current.json"

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -147,6 +147,22 @@ def test_ci_matrix_rejects_cla_status_write_permission(monkeypatch) -> None:
     assert ".github/workflows/cla-status.yml must not contain status write permission" in errors
 
 
+def test_ci_matrix_requires_paginated_cla_status_lookup(monkeypatch) -> None:
+    cla_status_text = ci_matrix.CLA_STATUS_WORKFLOW.read_text().replace("--paginate --slurp", "")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CLA_STATUS_WORKFLOW:
+            return cla_status_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert ".github/workflows/cla-status.yml is missing paginated status lookup" in errors
+
+
 def test_benchmark_regression_check_blocks_release(tmp_path, monkeypatch) -> None:
     baseline = tmp_path / "baseline.json"
     current = tmp_path / "current.json"

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -276,6 +276,7 @@ def _check_cla_status_workflow(errors: list[str]) -> None:
             "read-only status permission": "statuses: read",
             "CLA reporter job": "CLA status reported",
             "hosted CLA context": "license/cla",
+            "paginated status lookup": "--paginate --slurp",
             "CLA Assistant recheck URL": "https://cla-assistant.io/check/",
             "maintainer recovery procedure": "docs/maintaining/license-provenance.md",
         },

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -18,6 +18,7 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 BENCHMARK_PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "benchmark-pr.yml"
 LEGAL_INTEGRITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "legal-integrity.yml"
+CLA_STATUS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cla-status.yml"
 PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 RELEASE_CANDIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-candidate.yml"
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
@@ -265,6 +266,30 @@ def _check_security_workflow(errors: list[str]) -> None:
         errors.append("Security workflow dev audit must omit the editable project from exported requirements")
 
 
+def _check_cla_status_workflow(errors: list[str]) -> None:
+    _check_file_fragments(
+        errors,
+        CLA_STATUS_WORKFLOW,
+        {
+            "pull request trigger": "pull_request:",
+            "manual recovery trigger": "workflow_dispatch:",
+            "read-only status permission": "statuses: read",
+            "CLA reporter job": "CLA status reported",
+            "hosted CLA context": "license/cla",
+            "CLA Assistant recheck URL": "https://cla-assistant.io/check/",
+            "maintainer recovery procedure": "docs/maintaining/license-provenance.md",
+        },
+    )
+    _check_file_absent_fragments(
+        errors,
+        CLA_STATUS_WORKFLOW,
+        {
+            "status write permission": "statuses: write",
+            "pull-request write permission": "pull-requests: write",
+        },
+    )
+
+
 def check() -> list[str]:
     """Return support-matrix consistency errors."""
     errors: list[str] = []
@@ -274,6 +299,7 @@ def check() -> list[str]:
         _check_support_policy(errors, versions)
         _check_release_workflow(errors)
         _check_security_workflow(errors)
+        _check_cla_status_workflow(errors)
     return errors
 
 


### PR DESCRIPTION
## What changed

- Add a read-only `CLA Status Reporter` workflow for pull request and manual runs.
- Wait up to one minute for the hosted `license/cla` commit status.
- Fail with a direct CLA Assistant recheck link and maintainer instructions when the status is absent.
- Add a recovery runbook for webhook redelivery, dashboard recheck, and emergency verification.
- Extend the CI policy verifier so the reporter cannot gain status or pull-request write permission.

## Why

PR #114 received successful `opened` and `synchronize` webhook responses from CLA Assistant, but its asynchronous worker did not publish `license/cla`. GitHub therefore showed `Expected — Waiting for status to be reported` indefinitely even though every GitHub Actions job had completed.

The new reporter gives this failure mode a bounded, actionable check. It does not decide whether a contributor signed the CLA and cannot publish or override `license/cla`.

## Validation

- `uv run pytest -q`: 1,730 passed.
- `pre-commit run --all-files`: passed.
- `uv run python tools/ci_matrix.py check`: passed.

## Rollout after merge

Run `CLA Status Reporter` once from the default branch. After it succeeds, add `CLA status reported` to the `main` ruleset and restrict its source to GitHub Actions. Keep the existing hosted `license/cla` and `License, CLA, and package notices` requirements.

## Summary by Sourcery

Add a read-only CLA status reporting workflow and integrate it into CI policy verification and maintainer recovery procedures.

Enhancements:
- Document recovery steps and emergency procedures for missing `license/cla` commit statuses.

CI:
- Introduce a `CLA Status Reporter` GitHub Actions workflow that waits for the hosted `license/cla` status and surfaces actionable recheck guidance.
- Extend the CI support-matrix verifier to enforce triggers and read-only permissions for the CLA status workflow.

Documentation:
- Expand license provenance maintenance docs with a runbook for diagnosing and recovering missing CLA statuses and adding the reporter check to the `main` ruleset.

Tests:
- Add tests to ensure the CI matrix rejects CLA status workflows that request write permissions.