### PR TITLE
Bump version to 0.2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.5"
+version = "0.2.6"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from `0.2.5` to `0.2.6`
- keep the editable package entry in `uv.lock` aligned

## Impact

Prepares the next patch release without changing runtime behavior or dependencies.

## Validation

- `uv lock --check`
- `uv run pytest` (1,731 passed)
- `pre-commit run --all-files`

## Summary by Sourcery

Prepare the next patch release by updating the Albucore package version metadata.

New Features:
- Update Albucore project version from 0.2.5 to 0.2.6.

Build:
- Align uv.lock editable package entry with the new Albucore version.