### PR TITLE
Fix float64 operand promotion in float32 arithmetic

### DIFF
--- a/albucore/arithmetic.py
+++ b/albucore/arithmetic.py
@@ -1,6 +1,6 @@
 """Arithmetic: add, multiply, power, value-normalize, weighted sum, multiply-add."""
 
-from typing import Any, Literal, TypeGuard, cast
+from typing import Any, Literal, TypeAlias, TypeGuard, cast
 
 import cv2
 import numpy as np
@@ -26,6 +26,8 @@ from albucore.weighted import add_array_numkong, add_weighted_numkong, multiply_
 np_operations = {"multiply": np.multiply, "add": np.add, "power": np.power}
 
 cv2_operations = {"multiply": cv2.multiply, "add": cv2.add, "power": cv2.pow}
+
+_PreparedValue: TypeAlias = float | int | np.float32 | np.ndarray
 
 
 def _is_uint8_image(img: ImageType) -> TypeGuard[ImageUInt8]:
@@ -123,14 +125,23 @@ def _prepare_array_value(
     return value
 
 
+def _prepare_numpy_value(value: ValueType | np.floating[Any]) -> _PreparedValue:
+    if isinstance(value, np.ndarray):
+        return value.astype(np.float32, copy=False)
+    if isinstance(value, np.floating):
+        return np.float32(value)
+    return value
+
+
 def apply_numpy(
     img: ImageType,
-    value: float | np.ndarray,
+    value: ValueType | np.floating[Any],
     operation: Literal["add", "multiply", "power"],
 ) -> ImageFloat32:
-    value_prepared: float | np.ndarray = value
     if operation == "add" and img.dtype == np.uint8:
-        value_prepared = np.asarray(value, dtype=np.int16)
+        value_prepared: _PreparedValue = np.asarray(value, dtype=np.int16)
+    else:
+        value_prepared = _prepare_numpy_value(value)
 
     return cast("ImageFloat32", np_operations[operation](img.astype(np.float32, copy=False), value_prepared))
 
@@ -557,13 +568,13 @@ def add_weighted(img1: ImageType, weight1: float, img2: ImageType, weight2: floa
     return add_weighted_numkong(img1, weight1, img2, weight2)
 
 
-def _broadcast_channel_vector(x: ValueType, n_dim: int, c: int) -> float | np.ndarray:
+def _broadcast_channel_vector(x: _PreparedValue, n_dim: int, c: int) -> _PreparedValue:
     if isinstance(x, np.ndarray) and x.shape == (c,):
         return x.reshape((1,) * (n_dim - 1) + (c,))
     return x
 
 
-def _is_all_zero_param(x: float | np.ndarray) -> bool:
+def _is_all_zero_param(x: _PreparedValue) -> bool:
     if isinstance(x, np.ndarray):
         return not np.any(x)
     return float(x) == 0.0
@@ -580,13 +591,15 @@ def _use_numkong_scalar_multiply_add(img: ImageType, factor: ValueType, value: V
 
 def multiply_add_numpy(img: ImageType, factor: ValueType, value: ValueType) -> ImageFloat32:
     img_f = img.astype(np.float32, copy=False)
+    factor_prepared = _prepare_numpy_value(factor)
+    value_prepared = _prepare_numpy_value(value)
 
-    def _scalar_float(x: ValueType) -> float | None:
+    def _scalar_float(x: _PreparedValue) -> float | None:
         if isinstance(x, np.ndarray):
             return None
         return float(x)
 
-    sf, sv = _scalar_float(factor), _scalar_float(value)
+    sf, sv = _scalar_float(factor_prepared), _scalar_float(value_prepared)
     if sf is not None and sv is not None and sf == 0.0 and sv == 0.0:
         return np.zeros_like(img_f, dtype=np.float32)
 
@@ -595,8 +608,8 @@ def multiply_add_numpy(img: ImageType, factor: ValueType, value: ValueType) -> I
 
     n_dim = img_f.ndim
     c = int(img_f.shape[-1])
-    f_b = _broadcast_channel_vector(factor, n_dim, c)
-    v_b = _broadcast_channel_vector(value, n_dim, c)
+    f_b = _broadcast_channel_vector(factor_prepared, n_dim, c)
+    v_b = _broadcast_channel_vector(value_prepared, n_dim, c)
 
     result = np.zeros_like(img_f) if _is_all_zero_param(f_b) else np.multiply(img_f, f_b)
     return result if _is_all_zero_param(v_b) else np.add(result, v_b)

--- a/benchmarks/benchmark_float32_operand_dtypes.py
+++ b/benchmarks/benchmark_float32_operand_dtypes.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Benchmark float32 arithmetic with float64 ndarray operands.
+
+The legacy candidate intentionally leaves operands unchanged so NumPy creates a
+float64 result before the public clipping wrapper casts it back to float32. The
+current candidate normalizes the operand before image-sized arithmetic.
+
+Run from the repository root::
+
+    uv run python benchmarks/benchmark_float32_operand_dtypes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from collections.abc import Callable
+
+import numpy as np
+
+import albucore.arithmetic as arithmetic
+
+HWC_SHAPES = tuple((size, size, channels) for size in (256, 512, 1024) for channels in (1, 3, 5))
+
+
+def _legacy_apply_numpy(
+    img: np.ndarray,
+    value: float | np.ndarray,
+    operation: str,
+) -> np.ndarray:
+    return arithmetic.np_operations[operation](img.astype(np.float32, copy=False), value)
+
+
+def _legacy_multiply_add_numpy(
+    img: np.ndarray,
+    factor: float | np.ndarray,
+    value: float | np.ndarray,
+) -> np.ndarray:
+    img_f = img.astype(np.float32, copy=False)
+
+    def _scalar_float(x: float | np.ndarray) -> float | None:
+        return None if isinstance(x, np.ndarray) else float(x)
+
+    sf, sv = _scalar_float(factor), _scalar_float(value)
+    if sf is not None and sv is not None and sf == 0.0 and sv == 0.0:
+        return np.zeros_like(img_f, dtype=np.float32)
+    if sf is not None and sv is not None and sf == 1.0 and sv == 0.0:
+        return img_f
+
+    n_dim = img_f.ndim
+    channels = int(img_f.shape[-1])
+    factor_broadcast = arithmetic._broadcast_channel_vector(factor, n_dim, channels)  # noqa: SLF001
+    value_broadcast = arithmetic._broadcast_channel_vector(value, n_dim, channels)  # noqa: SLF001
+    result = (
+        np.zeros_like(img_f)
+        if arithmetic._is_all_zero_param(factor_broadcast)  # noqa: SLF001
+        else np.multiply(img_f, factor_broadcast)
+    )
+    return (
+        result
+        if arithmetic._is_all_zero_param(value_broadcast)  # noqa: SLF001
+        else np.add(result, value_broadcast)
+    )
+
+
+def _operand(operation: str, shape: tuple[int, int, int], dtype: np.dtype, rng: np.random.Generator) -> np.ndarray:
+    if operation == "add":
+        value = rng.uniform(-0.1, 0.1, size=shape)
+    elif operation == "multiply":
+        value = rng.uniform(0.8, 1.2, size=shape)
+    else:
+        value = rng.uniform(0.7, 1.3, size=shape)
+    return value.astype(dtype, copy=False)
+
+
+def _apply_thunk(operation: str, img: np.ndarray, value: np.ndarray) -> Callable[[], np.ndarray]:
+    public_operation = {
+        "add": arithmetic.add,
+        "multiply": arithmetic.multiply,
+        "power": arithmetic.power,
+    }[operation]
+    return lambda: public_operation(img, value)
+
+
+def _multiply_add_thunk(img: np.ndarray, factor: np.ndarray, value: np.ndarray) -> Callable[[], np.ndarray]:
+    return lambda: arithmetic.multiply_add(img, factor, value)
+
+
+def _time_apply(
+    operation: str,
+    img: np.ndarray,
+    value: np.ndarray,
+    repeats: int,
+    warmup: int,
+) -> tuple[float, float]:
+    current_apply_numpy = arithmetic.apply_numpy
+
+    def use_legacy() -> None:
+        arithmetic.apply_numpy = _legacy_apply_numpy  # type: ignore[assignment]
+
+    def use_current() -> None:
+        arithmetic.apply_numpy = current_apply_numpy
+
+    try:
+        return _paired_median_ms(_apply_thunk(operation, img, value), use_legacy, use_current, repeats, warmup)
+    finally:
+        arithmetic.apply_numpy = current_apply_numpy
+
+
+def _time_multiply_add(
+    img: np.ndarray,
+    factor: np.ndarray,
+    value: np.ndarray,
+    repeats: int,
+    warmup: int,
+) -> tuple[float, float]:
+    current_multiply_add_numpy = arithmetic.multiply_add_numpy
+
+    def use_legacy() -> None:
+        arithmetic.multiply_add_numpy = _legacy_multiply_add_numpy  # type: ignore[assignment]
+
+    def use_current() -> None:
+        arithmetic.multiply_add_numpy = current_multiply_add_numpy
+
+    try:
+        return _paired_median_ms(_multiply_add_thunk(img, factor, value), use_legacy, use_current, repeats, warmup)
+    finally:
+        arithmetic.multiply_add_numpy = current_multiply_add_numpy
+
+
+def _paired_median_ms(
+    thunk: Callable[[], np.ndarray],
+    use_legacy: Callable[[], None],
+    use_current: Callable[[], None],
+    repeats: int,
+    warmup: int,
+) -> tuple[float, float]:
+    for _ in range(warmup):
+        use_legacy()
+        thunk()
+        use_current()
+        thunk()
+
+    legacy_samples: list[float] = []
+    current_samples: list[float] = []
+    for index in range(repeats):
+        candidates = (
+            ((use_legacy, legacy_samples), (use_current, current_samples))
+            if index % 2 == 0
+            else ((use_current, current_samples), (use_legacy, legacy_samples))
+        )
+        for select, samples in candidates:
+            select()
+            started = time.perf_counter()
+            thunk()
+            samples.append((time.perf_counter() - started) * 1_000.0)
+
+    return float(np.median(legacy_samples)), float(np.median(current_samples))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeats", type=int, default=9)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=137)
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    print("# Float32 arithmetic operand dtype benchmark")
+    print()
+    print("Median milliseconds. Regression ratio is current / legacy for existing float32 operands.")
+    print()
+    print(
+        "| operation | shape | legacy float64 | current float64 | speedup | "
+        "legacy float32 | current float32 | regression ratio |",
+    )
+    print("|---|---:|---:|---:|---:|---:|---:|---:|")
+
+    for shape in HWC_SHAPES:
+        img = rng.uniform(0.05, 0.95, size=shape).astype(np.float32)
+        for operation in ("add", "multiply", "power"):
+            value_float64 = _operand(operation, shape, np.dtype(np.float64), rng)
+            value_float32 = value_float64.astype(np.float32)
+            legacy_float64, current_float64 = _time_apply(
+                operation,
+                img,
+                value_float64,
+                args.repeats,
+                args.warmup,
+            )
+            legacy_float32, current_float32 = _time_apply(
+                operation,
+                img,
+                value_float32,
+                args.repeats,
+                args.warmup,
+            )
+            print(
+                f"| {operation} | {'×'.join(map(str, shape))} | {legacy_float64:.4f} | {current_float64:.4f} | "
+                f"{legacy_float64 / current_float64:.2f}× | {legacy_float32:.4f} | {current_float32:.4f} | "
+                f"{current_float32 / legacy_float32:.3f}× |",
+            )
+
+        factor_float64 = _operand("multiply", shape, np.dtype(np.float64), rng)
+        value_float64 = _operand("add", shape, np.dtype(np.float64), rng)
+        legacy_float64, current_float64 = _time_multiply_add(
+            img,
+            factor_float64,
+            value_float64,
+            args.repeats,
+            args.warmup,
+        )
+        legacy_float32, current_float32 = _time_multiply_add(
+            img,
+            factor_float64.astype(np.float32),
+            value_float64.astype(np.float32),
+            args.repeats,
+            args.warmup,
+        )
+        print(
+            f"| multiply_add | {'×'.join(map(str, shape))} | {legacy_float64:.4f} | {current_float64:.4f} | "
+            f"{legacy_float64 / current_float64:.2f}× | {legacy_float32:.4f} | {current_float32:.4f} | "
+            f"{current_float32 / legacy_float32:.3f}× |",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_arithmetic_operand_dtypes.py
+++ b/tests/test_arithmetic_operand_dtypes.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from albucore import add, multiply, multiply_add, power
+from albucore.arithmetic import apply_numpy, multiply_add_numpy
+
+PUBLIC_OPERATIONS: dict[str, Callable[[np.ndarray, np.ndarray | float], np.ndarray]] = {
+    "add": add,
+    "multiply": multiply,
+    "power": power,
+}
+
+
+def _float64_operand(kind: str, shape: tuple[int, int, int]) -> np.ndarray | float:
+    if kind == "scalar":
+        return np.float64(0.9)
+    if kind == "vector":
+        return np.linspace(0.8, 1.0, shape[-1], dtype=np.float64)
+    if kind == "contiguous_array":
+        return np.linspace(0.8, 1.0, np.prod(shape), dtype=np.float64).reshape(shape)
+
+    expanded_shape = (shape[0], shape[1] * 2, shape[2])
+    operand = np.linspace(0.8, 1.0, np.prod(expanded_shape), dtype=np.float64).reshape(expanded_shape)
+    return operand[:, ::2, :]
+
+
+@pytest.mark.parametrize("operation", ["add", "multiply", "power"])
+@pytest.mark.parametrize("operand_kind", ["scalar", "vector", "contiguous_array", "strided_array"])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_float32_arithmetic_normalizes_float64_operands(
+    operation: str,
+    operand_kind: str,
+    channels: int,
+) -> None:
+    shape = (5, 7, channels)
+    img = np.linspace(0.1, 0.7, np.prod(shape), dtype=np.float32).reshape(shape)
+    operand = _float64_operand(operand_kind, shape)
+    if operand_kind == "strided_array":
+        assert isinstance(operand, np.ndarray)
+        assert not operand.flags.c_contiguous
+
+    result = apply_numpy(img, operand, operation)  # type: ignore[arg-type]
+    operand_float32 = np.asarray(operand, dtype=np.float32)
+    expected = getattr(np, operation)(img, operand_float32)
+
+    assert result.dtype == np.float32
+    assert result.shape == img.shape
+    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-7)
+
+    public_result = PUBLIC_OPERATIONS[operation](img, operand)
+    assert public_result.dtype == np.float32
+    assert public_result.shape == img.shape
+    np.testing.assert_allclose(public_result, np.clip(expected, 0, 1), rtol=1e-6, atol=1e-7)
+
+
+@pytest.mark.parametrize("parameter", ["factor", "value"])
+@pytest.mark.parametrize("operand_kind", ["scalar", "vector", "contiguous_array", "strided_array"])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_float32_multiply_add_normalizes_float64_operands(
+    parameter: str,
+    operand_kind: str,
+    channels: int,
+) -> None:
+    shape = (5, 7, channels)
+    img = np.linspace(0.1, 0.7, np.prod(shape), dtype=np.float32).reshape(shape)
+    operand = _float64_operand(operand_kind, shape)
+    factor = operand if parameter == "factor" else 0.5
+    value = operand if parameter == "value" else 0.1
+
+    result = multiply_add_numpy(img, factor, value)  # type: ignore[arg-type]
+    expected = np.multiply(img, np.asarray(factor, dtype=np.float32))
+    expected = np.add(expected, np.asarray(value, dtype=np.float32))
+
+    assert result.dtype == np.float32
+    assert result.shape == img.shape
+    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-7)
+
+    public_result = multiply_add(img, factor, value)  # type: ignore[arg-type]
+    assert public_result.dtype == np.float32
+    assert public_result.shape == img.shape
+    np.testing.assert_allclose(public_result, np.clip(expected, 0, 1), rtol=1e-6, atol=1e-7)


### PR DESCRIPTION
Closes #121.

## Summary

- Normalize NumPy scalar and array operands to `float32` before image-sized add, multiply, and power operations.
- Apply the same normalization to multiply-add factors and offsets found during the related-operation audit.
- Cover scalar, vector, contiguous full-array, and strided operands for 1, 3, and 5 channels.
- Add a paired benchmark that compares the legacy and fixed public routes.

## Root cause and impact

`apply_numpy` kept ndarray operands at their original dtype. A float32 image combined with a float64 operand therefore produced a full float64 result. The clipping wrapper then clipped that result and cast another image-sized array back to float32. Normalizing the operand first keeps arithmetic and clipping in float32; operands that are already float32 use `astype(copy=False)` and do not allocate a conversion buffer.

The audit found the same promotion in `multiply_add_numpy`. Normalize, OpenCV arithmetic, LUT, weighted, and unary elementwise paths already constrain their working dtype or do not accept ndarray arithmetic operands, so their routing remains unchanged.

## Benchmark

Measured on macOS 26.4.1 arm64 with Python 3.10.16, NumPy 2.2.6, and OpenCV 5.0.0. The paired benchmark used 5 warmups and 21 timed repeats for 256/512/1024 images with 1/3/5 channels.

- Add, multiply, and power with float64 arrays improved by 1.72–1.98×.
- Multiply-add with float64 arrays improved by 1.17–1.25×.
- Existing float32-array routes had a worst measured slowdown of 2.9%, below the issue's 5% threshold.

Run with:

```bash
uv run python benchmarks/benchmark_float32_operand_dtypes.py --repeats 21 --warmup 5
```

## Validation

- `uv run pytest -q` — 1,870 passed
- `pre-commit run --all-files` — passed
- `uv run mypy albucore` — passed

## Summary by Sourcery

Normalize float64 NumPy operands to float32 in image arithmetic paths and validate and benchmark the new behavior.

New Features:
- Introduce operand preparation helper to ensure NumPy scalar and array operands use float32 in apply_numpy and multiply_add_numpy.
- Add a benchmark script comparing legacy and current float32 arithmetic performance with float64 and float32 operands across image sizes and channel counts.

Bug Fixes:
- Prevent unintended promotion of float32 image arithmetic results to float64 when using float64 NumPy operands in apply_numpy and multiply_add_numpy.

Enhancements:
- Unify operand handling with a shared prepared value type to support scalar, vector, contiguous, and strided array operands in multi-channel images.

Tests:
- Add tests that verify float64 scalar, vector, contiguous, and strided operands are normalized to float32 and produce correct results for add, multiply, power, and multiply-add operations.