### PR TITLE
Fix arithmetic operand normalization and OpenCV channel limits

### DIFF
--- a/albucore/arithmetic.py
+++ b/albucore/arithmetic.py
@@ -1,5 +1,6 @@
 """Arithmetic: add, multiply, power, value-normalize, weighted sum, multiply-add."""
 
+import math
 from typing import Any, Literal, TypeAlias, TypeGuard, cast
 
 import cv2
@@ -27,7 +28,11 @@ np_operations = {"multiply": np.multiply, "add": np.add, "power": np.power}
 
 cv2_operations = {"multiply": cv2.multiply, "add": cv2.add, "power": cv2.pow}
 
-_PreparedValue: TypeAlias = float | int | np.float32 | np.ndarray
+_PreparedValue: TypeAlias = float | int | np.floating[Any] | np.ndarray
+_FLOAT32_COMPATIBLE_OPERAND_DTYPES: frozenset[np.dtype[Any]] = frozenset(
+    np.dtype(dtype) for dtype in (np.bool_, np.uint8, np.int8, np.uint16, np.int16, np.float16, np.float32)
+)
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
 
 
 def _is_uint8_image(img: ImageType) -> TypeGuard[ImageUInt8]:
@@ -127,9 +132,24 @@ def _prepare_array_value(
 
 def _prepare_numpy_value(value: ValueType | np.floating[Any]) -> _PreparedValue:
     if isinstance(value, np.ndarray):
-        return value.astype(np.float32, copy=False)
+        if value.dtype in _FLOAT32_COMPATIBLE_OPERAND_DTYPES or np.result_type(np.float32, value.dtype) == np.float32:
+            return value
+        try:
+            with np.errstate(over="raise"):
+                return value.astype(np.float32, copy=False)
+        except FloatingPointError:
+            # Preserve finite values outside the float32 range until after the
+            # arithmetic. Narrowing them first would turn them into infinities
+            # and make otherwise defined operations such as 0 * 1e40 return NaN.
+            return value
     if isinstance(value, np.floating):
-        return np.float32(value)
+        try:
+            with np.errstate(over="raise"):
+                return np.float32(value)
+        except FloatingPointError:
+            pass
+    elif isinstance(value, float) and math.isfinite(value) and not -_FLOAT32_MAX <= value <= _FLOAT32_MAX:
+        value = np.float64(value)
     return value
 
 
@@ -143,7 +163,11 @@ def apply_numpy(
     else:
         value_prepared = _prepare_numpy_value(value)
 
-    return cast("ImageFloat32", np_operations[operation](img.astype(np.float32, copy=False), value_prepared))
+    result = np_operations[operation](img.astype(np.float32, copy=False), value_prepared)
+    if result.dtype == np.float32:
+        return cast("ImageFloat32", result)
+    with np.errstate(over="ignore"):
+        return cast("ImageFloat32", result.astype(np.float32, copy=False))
 
 
 def multiply_lut(img: ImageUInt8, value: np.ndarray | float, inplace: bool = False) -> ImageUInt8:
@@ -585,6 +609,8 @@ def _use_numkong_scalar_multiply_add(img: ImageType, factor: ValueType, value: V
         _is_float32_image(img)
         and isinstance(factor, (float, int))
         and isinstance(value, (float, int))
+        and -_FLOAT32_MAX <= factor <= _FLOAT32_MAX
+        and -_FLOAT32_MAX <= value <= _FLOAT32_MAX
         and img.size >= 1_000_000
     )
 
@@ -612,7 +638,11 @@ def multiply_add_numpy(img: ImageType, factor: ValueType, value: ValueType) -> I
     v_b = _broadcast_channel_vector(value_prepared, n_dim, c)
 
     result = np.zeros_like(img_f) if _is_all_zero_param(f_b) else np.multiply(img_f, f_b)
-    return result if _is_all_zero_param(v_b) else np.add(result, v_b)
+    result = result if _is_all_zero_param(v_b) else np.add(result, v_b)
+    if result.dtype == np.float32:
+        return cast("ImageFloat32", result)
+    with np.errstate(over="ignore"):
+        return cast("ImageFloat32", result.astype(np.float32, copy=False))
 
 
 @preserve_channel_dim

--- a/albucore/geometric.py
+++ b/albucore/geometric.py
@@ -14,12 +14,19 @@ import cv2
 import numpy as np
 
 from albucore.decorators import preserve_channel_dim
-from albucore.utils import MAX_OPENCV_WORKING_CHANNELS, ImageType, get_num_channels, maybe_process_in_chunks
+from albucore.utils import (
+    MAX_OPENCV_WORKING_CHANNELS,
+    ImageType,
+    get_num_channels,
+    get_opencv_max_channels,
+    maybe_process_in_chunks,
+)
 
 # Interpolations that require chunking for >4ch (CI: _src.channels() <= 4)
 _INTERP_NEEDS_CHUNK = {cv2.INTER_CUBIC, cv2.INTER_LANCZOS4, cv2.INTER_LINEAR_EXACT}
 # remap does not support INTER_LINEAR_EXACT; only CUBIC/LANCZOS4 need chunking
 _REMAP_INTERP_NEEDS_CHUNK = {cv2.INTER_CUBIC, cv2.INTER_LANCZOS4}
+_MAX_OPENCV_CHANNELS = get_opencv_max_channels()
 
 __all__ = [
     "copy_make_border",
@@ -146,11 +153,12 @@ def warp_affine(
 
     Accepts 2x3 or 3x3 affine matrix (3x3 uses first two rows).
 
-    OpenCV warpAffine accepts >4 channels when:
+    OpenCV warpAffine accepts >4 channels up to its encoded channel limit when:
     - Interpolation is INTER_NEAREST, INTER_LINEAR, or INTER_AREA
     - border_value is scalar or len <= 4
 
     We chunk when:
+    - C exceeds OpenCV's encoded channel limit
     - C > 4 AND (flags in {INTER_CUBIC, INTER_LANCZOS4, INTER_LINEAR_EXACT} OR border_value_cv2 is None)
     - border_value_cv2 is None: per-channel border_value len>4 → _warp_affine_chunked
     - border_value_cv2 is not None: uniform border_value → maybe_process_in_chunks
@@ -172,7 +180,7 @@ def warp_affine(
     border_value_cv2 = _border_value_for_cv2(border_value) if border_value is not None else 0
 
     needs_chunk = num_channels > MAX_OPENCV_WORKING_CHANNELS and (
-        flags in _INTERP_NEEDS_CHUNK or border_value_cv2 is None
+        num_channels > _MAX_OPENCV_CHANNELS or flags in _INTERP_NEEDS_CHUNK or border_value_cv2 is None
     )
     if needs_chunk:
         if border_value_cv2 is None:
@@ -238,11 +246,12 @@ def warp_perspective(
 ) -> ImageType:
     """Perspective warp. Drop-in for cv2.warpPerspective with multi-channel support.
 
-    OpenCV warpPerspective accepts >4 channels when:
+    OpenCV warpPerspective accepts >4 channels up to its encoded channel limit when:
     - Interpolation is INTER_NEAREST, INTER_LINEAR, or INTER_AREA
     - border_value is scalar or len <= 4
 
     We chunk when:
+    - C exceeds OpenCV's encoded channel limit
     - C > 4 AND (flags in {INTER_CUBIC, INTER_LANCZOS4, INTER_LINEAR_EXACT} OR border_value_cv2 is None)
     - border_value_cv2 is None: per-channel border_value len>4 → _warp_perspective_chunked
     - border_value_cv2 is not None: uniform border_value → maybe_process_in_chunks
@@ -263,7 +272,7 @@ def warp_perspective(
     border_value_cv2 = _border_value_for_cv2(border_value) if border_value is not None else 0
 
     needs_chunk = num_channels > MAX_OPENCV_WORKING_CHANNELS and (
-        flags in _INTERP_NEEDS_CHUNK or border_value_cv2 is None
+        num_channels > _MAX_OPENCV_CHANNELS or flags in _INTERP_NEEDS_CHUNK or border_value_cv2 is None
     )
     if needs_chunk:
         if border_value_cv2 is None:
@@ -409,8 +418,10 @@ def remap(
 ) -> ImageType:
     """Remap image. Drop-in for cv2.remap with multi-channel support.
 
-    cv2.remap works for >4 channels when interpolation is NEAREST, LINEAR, or AREA,
-    and border_value is scalar or len<=4. We chunk when:
+    cv2.remap works for >4 channels up to its encoded channel limit when
+    interpolation is NEAREST, LINEAR, or AREA and border_value is scalar or
+    len<=4. We chunk when:
+    - C exceeds OpenCV's encoded channel limit
     - C > 4 AND (interpolation in {CUBIC, LANCZOS4} OR per-channel border_value len>4)
 
     Args:
@@ -429,7 +440,7 @@ def remap(
     border_value_cv2 = _border_value_for_cv2(border_value) if border_value is not None else 0
 
     needs_chunk = num_channels > MAX_OPENCV_WORKING_CHANNELS and (
-        interpolation in _REMAP_INTERP_NEEDS_CHUNK or border_value_cv2 is None
+        num_channels > _MAX_OPENCV_CHANNELS or interpolation in _REMAP_INTERP_NEEDS_CHUNK or border_value_cv2 is None
     )
     if needs_chunk:
         if border_value_cv2 is None:

--- a/albucore/ops_misc.py
+++ b/albucore/ops_misc.py
@@ -15,10 +15,11 @@ from albucore.utils import (
     ImageFloat32,
     ImageType,
     get_num_channels,
+    get_opencv_max_channels,
     maybe_process_in_chunks,
 )
 
-MAX_OPENCV_FLIP_CHANNELS = 128
+MAX_OPENCV_FLIP_CHANNELS = get_opencv_max_channels()
 
 
 @contiguous
@@ -89,9 +90,9 @@ def vflip(img: ImageType) -> ImageType:
 def _flip_multichannel(img: ImageType, flip_code: int) -> ImageType:
     """Process images with more than OpenCV's flip channel limit.
 
-    OpenCV 5 handles up to 128 channels for ``cv2.flip`` on this wheel. This
-    function works around that limit by splitting wider images into safe chunks,
-    flipping each chunk separately, and then concatenating the results.
+    OpenCV's maximum encoded channel count depends on the major version. This
+    function works around the active build's limit by splitting wider images
+    into safe chunks, flipping each chunk separately, and then joining the results.
 
     Args:
         img: Input image with many channels

--- a/albucore/utils.py
+++ b/albucore/utils.py
@@ -40,6 +40,16 @@ NPDTYPE_TO_OPENCV_DTYPE: dict[np.dtype | type, int] = {
 }
 
 
+def get_opencv_max_channels() -> int:
+    """Return the maximum channel count encodable by this OpenCV build.
+
+    OpenCV stores the channel count in the matrix type. The bit layout changed
+    between OpenCV 4 and 5, so deriving the limit keeps routing correct for both.
+    """
+    channel_stride = cv2.CV_MAKETYPE(cv2.CV_8U, 2) - cv2.CV_MAKETYPE(cv2.CV_8U, 1)
+    return int((cv2.MAT_TYPE_MASK + 1) // channel_stride)
+
+
 def maybe_process_in_chunks(
     process_fn: Callable[Concatenate[np.ndarray, P], np.ndarray],
     *args: P.args,
@@ -380,6 +390,7 @@ __all__ = [
     "get_max_value",
     "get_num_channels",
     "get_opencv_dtype_from_numpy",
+    "get_opencv_max_channels",
     "is_grayscale_image",
     "is_multispectral_image",
     "is_rgb_image",

--- a/benchmarks/benchmark_float32_operand_dtypes.py
+++ b/benchmarks/benchmark_float32_operand_dtypes.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Benchmark float32 arithmetic with float64 ndarray operands.
+"""Benchmark float32 arithmetic across accepted ndarray operand dtypes.
 
 The legacy candidate intentionally leaves operands unchanged so NumPy creates a
-float64 result before the public clipping wrapper casts it back to float32. The
-current candidate normalizes the operand before image-sized arithmetic.
+promoted result where required. The current candidate normalizes only operands
+that would promote float32 image arithmetic, avoiding copies for uint8, float16,
+and float32 operands.
 
 Run from the repository root::
 
@@ -20,7 +21,12 @@ import numpy as np
 
 import albucore.arithmetic as arithmetic
 
-HWC_SHAPES = tuple((size, size, channels) for size in (256, 512, 1024) for channels in (1, 3, 5))
+HWC_SHAPES = tuple(
+    (height, width, channels)
+    for height, width in ((128, 160), (240, 320), (480, 640), (768, 1024))
+    for channels in (1, 3, 9)
+)
+OPERAND_DTYPES = tuple(np.dtype(dtype) for dtype in (np.uint8, np.float16, np.float32, np.float64))
 
 
 def _legacy_apply_numpy(
@@ -64,6 +70,8 @@ def _legacy_multiply_add_numpy(
 
 
 def _operand(operation: str, shape: tuple[int, int, int], dtype: np.dtype, rng: np.random.Generator) -> np.ndarray:
+    if np.issubdtype(dtype, np.integer):
+        return rng.integers(0, 4, size=shape, dtype=dtype)
     if operation == "add":
         value = rng.uniform(-0.1, 0.1, size=shape)
     elif operation == "multiply":
@@ -168,60 +176,42 @@ def main() -> None:
     rng = np.random.default_rng(args.seed)
     print("# Float32 arithmetic operand dtype benchmark")
     print()
-    print("Median milliseconds. Regression ratio is current / legacy for existing float32 operands.")
+    print("Median milliseconds. Ratio is current / legacy; values below 1 are faster.")
     print()
-    print(
-        "| operation | shape | legacy float64 | current float64 | speedup | "
-        "legacy float32 | current float32 | regression ratio |",
-    )
-    print("|---|---:|---:|---:|---:|---:|---:|---:|")
+    print("| operation | shape | operand dtype | legacy | current | ratio |")
+    print("|---|---:|---:|---:|---:|---:|")
 
     for shape in HWC_SHAPES:
         img = rng.uniform(0.05, 0.95, size=shape).astype(np.float32)
         for operation in ("add", "multiply", "power"):
-            value_float64 = _operand(operation, shape, np.dtype(np.float64), rng)
-            value_float32 = value_float64.astype(np.float32)
-            legacy_float64, current_float64 = _time_apply(
-                operation,
+            for operand_dtype in OPERAND_DTYPES:
+                operand = _operand(operation, shape, operand_dtype, rng)
+                legacy_ms, current_ms = _time_apply(
+                    operation,
+                    img,
+                    operand,
+                    args.repeats,
+                    args.warmup,
+                )
+                print(
+                    f"| {operation} | {'×'.join(map(str, shape))} | {operand_dtype.name} | "
+                    f"{legacy_ms:.4f} | {current_ms:.4f} | {current_ms / legacy_ms:.3f}× |",
+                )
+
+        for operand_dtype in OPERAND_DTYPES:
+            factor = _operand("multiply", shape, operand_dtype, rng)
+            value = _operand("add", shape, operand_dtype, rng)
+            legacy_ms, current_ms = _time_multiply_add(
                 img,
-                value_float64,
-                args.repeats,
-                args.warmup,
-            )
-            legacy_float32, current_float32 = _time_apply(
-                operation,
-                img,
-                value_float32,
+                factor,
+                value,
                 args.repeats,
                 args.warmup,
             )
             print(
-                f"| {operation} | {'×'.join(map(str, shape))} | {legacy_float64:.4f} | {current_float64:.4f} | "
-                f"{legacy_float64 / current_float64:.2f}× | {legacy_float32:.4f} | {current_float32:.4f} | "
-                f"{current_float32 / legacy_float32:.3f}× |",
+                f"| multiply_add | {'×'.join(map(str, shape))} | {operand_dtype.name} | "
+                f"{legacy_ms:.4f} | {current_ms:.4f} | {current_ms / legacy_ms:.3f}× |",
             )
-
-        factor_float64 = _operand("multiply", shape, np.dtype(np.float64), rng)
-        value_float64 = _operand("add", shape, np.dtype(np.float64), rng)
-        legacy_float64, current_float64 = _time_multiply_add(
-            img,
-            factor_float64,
-            value_float64,
-            args.repeats,
-            args.warmup,
-        )
-        legacy_float32, current_float32 = _time_multiply_add(
-            img,
-            factor_float64.astype(np.float32),
-            value_float64.astype(np.float32),
-            args.repeats,
-            args.warmup,
-        )
-        print(
-            f"| multiply_add | {'×'.join(map(str, shape))} | {legacy_float64:.4f} | {current_float64:.4f} | "
-            f"{legacy_float64 / current_float64:.2f}× | {legacy_float32:.4f} | {current_float32:.4f} | "
-            f"{current_float32 / legacy_float32:.3f}× |",
-        )
 
 
 if __name__ == "__main__":

--- a/docs/maintaining/opencv-5-routing-plan.md
+++ b/docs/maintaining/opencv-5-routing-plan.md
@@ -18,8 +18,8 @@ Implemented changes:
   and the latest resolver-compatible NumPy set.
 - Added `benchmarks/probes/opencv_behavior_probe.py` and saved raw OpenCV 5
   behavior evidence in `benchmarks/results/opencv5-routing/opencv5_behavior_probe.json`.
-- Updated `hflip_cv2` / `vflip_cv2` chunking to OpenCV 5's measured
-  `cv2.flip` limit of 128 channels.
+- Updated `hflip_cv2` / `vflip_cv2` chunking to derive the matrix-type channel
+  limit from the active OpenCV build (128 on OpenCV 5 and 512 on OpenCV 4).
 - Recalibrated shared HWC uint8 LUT routing for the OpenCV 5 + StringZilla 4.6.2
   stack.
 - Routed `std(..., "per_channel")` and `mean_std(..., "per_channel")` through

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -15,7 +15,7 @@ User-facing entry points with benchmark-driven backends inside:
 - **Decorators:** see `decorators.__all__` in [`albucore/decorators.py`](../albucore/decorators.py)
 - **Geometric:** `copy_make_border`, `remap`, `resize`, `warp_affine`, `warp_perspective`
 - **Utils:** see `utils.__all__` in [`albucore/utils.py`](../albucore/utils.py)
-- **Types / constants:** `ImageType`, `ImageUInt8`, `ImageFloat32`, `SupportedDType`, `NormalizationType`, `ValueType`, `MAX_OPENCV_WORKING_CHANNELS`, etc.
+- **Types / constants:** `ImageType`, `ImageUInt8`, `ImageFloat32`, `SupportedDType`, `NormalizationType`, `ValueType`, `MAX_OPENCV_WORKING_CHANNELS`, `get_opencv_max_channels`, etc.
 - **Metadata:** `__version__`, `__author__`, `__maintainer__`
 
 ## Shims (submodule-only, not star-exported)

--- a/tests/test_arithmetic_operand_dtypes.py
+++ b/tests/test_arithmetic_operand_dtypes.py
@@ -4,13 +4,143 @@ import numpy as np
 import pytest
 
 from albucore import add, multiply, multiply_add, power
-from albucore.arithmetic import apply_numpy, multiply_add_numpy
+from albucore.arithmetic import _prepare_numpy_value, apply_numpy, multiply_add_numpy
 
 PUBLIC_OPERATIONS: dict[str, Callable[[np.ndarray, np.ndarray | float], np.ndarray]] = {
     "add": add,
     "multiply": multiply,
     "power": power,
 }
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float16, np.float32])
+def test_prepare_numpy_value_reuses_operands_that_resolve_to_float32(dtype: type[np.generic]) -> None:
+    operand = np.ones((5, 7, 3), dtype=dtype)
+
+    assert _prepare_numpy_value(operand) is operand
+
+
+@pytest.mark.parametrize("operation", ["add", "multiply", "power"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float16])
+def test_float32_arithmetic_avoids_copy_for_compatible_operand_dtypes(
+    operation: str,
+    dtype: type[np.generic],
+) -> None:
+    shape = (5, 7, 3)
+    img = np.linspace(0.1, 0.7, np.prod(shape), dtype=np.float32).reshape(shape)
+    operand = np.full(shape, 1, dtype=dtype)
+
+    result = apply_numpy(img, operand, operation)  # type: ignore[arg-type]
+    expected = getattr(np, operation)(img, operand)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("operation", ["add", "multiply", "power"])
+def test_float32_arithmetic_preserves_finite_float64_operands_outside_float32_range(operation: str) -> None:
+    img = np.array([0.0, 1e-40, 0.5, 1.0], dtype=np.float32).reshape(2, 2, 1)
+    operand = np.full(img.shape, 1e40, dtype=np.float64)
+
+    with np.errstate(over="ignore"):
+        narrowed_operand = operand.astype(np.float32)
+    assert np.isfinite(operand).all()
+    assert np.isinf(narrowed_operand).all()
+
+    result = apply_numpy(img, operand, operation)
+    with np.errstate(over="ignore"):
+        expected = getattr(np, operation)(img, operand).astype(np.float32)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+
+    public_result = PUBLIC_OPERATIONS[operation](img, operand)
+    expected_public = np.clip(expected, 0, 1).astype(np.float32)
+    assert public_result.dtype == np.float32
+    np.testing.assert_array_equal(public_result, expected_public)
+
+
+@pytest.mark.parametrize("operation", ["add", "multiply", "power"])
+@pytest.mark.parametrize("operand", [1e40, np.float64(1e40)], ids=["python_float", "numpy_float64"])
+def test_float32_arithmetic_preserves_finite_scalars_outside_float32_range(
+    operation: str,
+    operand: float | np.float64,
+) -> None:
+    img = np.array([0.0, 1e-40, 0.5, 1.0], dtype=np.float32).reshape(2, 2, 1)
+    operand_float64 = np.float64(operand)
+
+    result = apply_numpy(img, operand, operation)
+    with np.errstate(over="ignore"):
+        expected = getattr(np, operation)(img, operand_float64).astype(np.float32)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+
+    public_result = PUBLIC_OPERATIONS[operation](img, operand)  # type: ignore[arg-type]
+    expected_public = np.clip(expected, 0, 1).astype(np.float32)
+    assert public_result.dtype == np.float32
+    np.testing.assert_array_equal(public_result, expected_public)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float16])
+def test_float32_multiply_add_avoids_copy_for_compatible_operand_dtypes(dtype: type[np.generic]) -> None:
+    shape = (5, 7, 3)
+    img = np.linspace(0.1, 0.7, np.prod(shape), dtype=np.float32).reshape(shape)
+    factor = np.full(shape, 1, dtype=dtype)
+    value = np.full(shape, 0, dtype=dtype)
+
+    result = multiply_add_numpy(img, factor, value)
+
+    assert _prepare_numpy_value(factor) is factor
+    assert _prepare_numpy_value(value) is value
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, img)
+
+
+def test_float32_multiply_add_preserves_finite_float64_operand_outside_float32_range() -> None:
+    img = np.array([0.0, 1e-40, 0.5, 1.0], dtype=np.float32).reshape(2, 2, 1)
+    factor = np.full(img.shape, 1e40, dtype=np.float64)
+
+    result = multiply_add_numpy(img, factor, 0.0)
+    with np.errstate(over="ignore"):
+        expected = np.multiply(img, factor).astype(np.float32)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+
+    public_result = multiply_add(img, factor, 0.0)
+    expected_public = np.clip(expected, 0, 1).astype(np.float32)
+    assert public_result.dtype == np.float32
+    np.testing.assert_array_equal(public_result, expected_public)
+
+
+@pytest.mark.parametrize("factor", [1e40, np.float64(1e40)], ids=["python_float", "numpy_float64"])
+def test_float32_multiply_add_preserves_finite_scalar_outside_float32_range(
+    factor: float | np.float64,
+) -> None:
+    img = np.array([0.0, 1e-40, 0.5, 1.0], dtype=np.float32).reshape(2, 2, 1)
+    factor_float64 = np.float64(factor)
+
+    result = multiply_add_numpy(img, factor, 0.0)  # type: ignore[arg-type]
+    with np.errstate(over="ignore"):
+        expected = np.multiply(img, factor_float64).astype(np.float32)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+
+    public_result = multiply_add(img, factor, 0.0)  # type: ignore[arg-type]
+    expected_public = np.clip(expected, 0, 1).astype(np.float32)
+    assert public_result.dtype == np.float32
+    np.testing.assert_array_equal(public_result, expected_public)
+
+
+def test_float32_multiply_add_avoids_numkong_for_scalar_outside_float32_range() -> None:
+    img = np.zeros((1_000_000, 1, 1), dtype=np.float32)
+
+    result = multiply_add(img, 1e40, 0.0)
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, img)
 
 
 def _float64_operand(kind: str, shape: tuple[int, int, int]) -> np.ndarray | float:

--- a/tests/test_arithmetic_operand_dtypes.py
+++ b/tests/test_arithmetic_operand_dtypes.py
@@ -13,7 +13,10 @@ PUBLIC_OPERATIONS: dict[str, Callable[[np.ndarray, np.ndarray | float], np.ndarr
 }
 
 
-@pytest.mark.parametrize("dtype", [np.uint8, np.float16, np.float32])
+@pytest.mark.parametrize(
+    "dtype",
+    [np.bool_, np.uint8, np.int8, np.uint16, np.int16, np.float16, np.float32],
+)
 def test_prepare_numpy_value_reuses_operands_that_resolve_to_float32(dtype: type[np.generic]) -> None:
     operand = np.ones((5, 7, 3), dtype=dtype)
 

--- a/tests/test_geometric.py
+++ b/tests/test_geometric.py
@@ -16,6 +16,7 @@ from albucore.geometric import (
     remap,
     resize,
 )
+from albucore.utils import get_opencv_max_channels
 
 # -----------------------------------------------------------------------------
 # Fixtures
@@ -39,6 +40,41 @@ def make_image(h: int, w: int, channels: int, dtype: type, rng: np.random.Genera
     else:
         img = rng.random((h, w, channels), dtype=np.float32)
     return np.ascontiguousarray(img)
+
+
+@pytest.mark.parametrize(
+    "channels",
+    [
+        get_opencv_max_channels(),
+        get_opencv_max_channels() + 1,
+        get_opencv_max_channels() + 64,
+    ],
+    ids=["at_limit", "above_limit", "well_above_limit"],
+)
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32], ids=["uint8", "float32"])
+@pytest.mark.parametrize("operation", ["remap", "warp_affine", "warp_perspective"])
+def test_geometric_identity_at_opencv_channel_boundary(channels: int, dtype: type, operation: str) -> None:
+    """Identity transforms preserve channels across OpenCV's encoded limit."""
+    height, width = 8, 8
+    channel_values = np.arange(channels, dtype=np.int64).astype(dtype)
+    img = np.broadcast_to(channel_values, (height, width, channels)).copy()
+    map_x, map_y = np.meshgrid(
+        np.arange(width, dtype=np.float32),
+        np.arange(height, dtype=np.float32),
+    )
+    affine = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    perspective = np.eye(3, dtype=np.float32)
+
+    if operation == "remap":
+        result = remap(img, map_x, map_y, interpolation=cv2.INTER_NEAREST)
+    elif operation == "warp_affine":
+        result = warp_affine(img, affine, (width, height), flags=cv2.INTER_NEAREST)
+    else:
+        result = warp_perspective(img, perspective, (width, height), flags=cv2.INTER_NEAREST)
+
+    assert result.shape == img.shape
+    assert result.dtype == img.dtype
+    np.testing.assert_array_equal(result, img)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,16 @@ import pytest
 import cv2
 from albucore.decorators import contiguous
 from albucore.functions import float32_io, from_float, to_float, uint8_io
-from albucore.utils import NPDTYPE_TO_OPENCV_DTYPE, clip, convert_value, get_opencv_dtype_from_numpy, get_num_channels, is_grayscale_image, get_image_data
+from albucore.utils import (
+    NPDTYPE_TO_OPENCV_DTYPE,
+    clip,
+    convert_value,
+    get_image_data,
+    get_num_channels,
+    get_opencv_dtype_from_numpy,
+    get_opencv_max_channels,
+    is_grayscale_image,
+)
 
 
 @pytest.mark.parametrize("input_img, dtype, expected", [
@@ -31,6 +40,13 @@ def test_cv_dtype_from_np():
     assert get_opencv_dtype_from_numpy(np.float32) == cv2.CV_32F
     assert get_opencv_dtype_from_numpy(np.dtype("uint8")) == cv2.CV_8U
     assert get_opencv_dtype_from_numpy(np.dtype("float32")) == cv2.CV_32F
+
+
+def test_get_opencv_max_channels_matches_matrix_type_encoding():
+    max_channels = get_opencv_max_channels()
+
+    assert cv2.CV_MAKETYPE(cv2.CV_8U, max_channels) <= cv2.MAT_TYPE_MASK
+    assert cv2.CV_MAKETYPE(cv2.CV_8U, max_channels + 1) > cv2.MAT_TYPE_MASK
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Preserve finite float64 operands outside the float32 range until arithmetic completes, preventing cases such as `0 * 1e40` from becoming `NaN`.
- Avoid image-sized float32 conversions for ndarray operands whose dtype already resolves to float32, including uint8 and float16.
- Derive OpenCV's encoded channel limit from the active build and chunk flip, warp, and remap operations above that boundary.
- Extend regression coverage and the arithmetic benchmark across operand dtypes, non-square shapes, and high-channel images.

## Root cause

The float32 arithmetic optimization narrowed every ndarray operand before executing the operation. Finite float64 values outside the float32 range became infinities, while compatible uint8 and float16 operands incurred unnecessary full-array allocations. Separately, the OpenCV 5 channel limit was hard-coded as 128 even though OpenCV 4 encodes up to 512 channels, and geometric operations did not chunk above the active build's limit.

## Impact

Common float64 operand paths retain their performance improvement without regressing compatible operand dtypes. Extreme finite operands preserve legacy arithmetic semantics, and high-channel geometric operations preserve shape and values across OpenCV 4 and 5.

## Validation

- `uv run pytest -q` — 1913 passed
- `pre-commit run --all-files` — all hooks passed
- NumPy 1.24.4 overflow-guard compatibility check
- OpenCV 4.13 boundary checks at 512/513/576 channels
- OpenCV 5.0 boundary checks at 128/129/192 channels
- Operand benchmark across uint8, float16, float32, and float64 on the canonical non-square 1/3/9-channel grid

Closes #113

## Summary by Sourcery

Adjust arithmetic and geometric operations to better respect dtype semantics and OpenCV’s encoded channel limits across versions.

New Features:
- Expose get_opencv_max_channels utility to derive the maximum encodable channel count from the active OpenCV build.

Bug Fixes:
- Preserve finite float64 and scalar operands outside the float32 range during arithmetic, avoiding NaNs from premature narrowing.
- Avoid unnecessary float32 copies for ndarray operands whose dtypes already resolve to float32, including uint8 and float16.
- Chunk remap, warp_affine, warp_perspective, and flip operations based on the active OpenCV build’s channel limit rather than a hard-coded threshold.

Enhancements:
- Extend float32 arithmetic benchmarks to cover multiple operand dtypes, non-square shapes, and multiply_add, and report performance as current/legacy ratios.
- Broaden regression tests for arithmetic and geometric paths to cover extreme operands, scalar behavior, and OpenCV channel boundary conditions.

Documentation:
- Update OpenCV routing documentation and public API docs to reflect dynamic channel limit detection and the new get_opencv_max_channels helper.