### PR TITLE
chore(release): bump version to 0.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.6"
+version = "0.2.7"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from `0.2.6` to `0.2.7`
- keep `uv.lock` package metadata aligned with `pyproject.toml`

## Why

Prepare the next patch release using the repository's version-only release workflow.

## Impact

No runtime behavior or dependency changes.

## Validation

- `uv lock --check`
- `uv run pytest` — 1,949 passed
- `pre-commit run --all-files`

## Summary by Sourcery

Build:
- Update albucore package version to 0.2.7 in pyproject.toml and refresh uv.lock metadata for the release.