### PR TITLE
fix: suppress spurious macOS matmul warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,39 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  macos-arm64-matmul:
+    name: macOS arm64 matmul warning regressions
+    needs: change_scope
+    if: needs.change_scope.outputs.run_tests == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.10"
+          activate-environment: true
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install regression-test dependencies
+        run: uv pip install -e ".[headless]" "numpy==2.2.6" "pytest>=9.0.3"
+
+      - name: Verify arm64 runner
+        run: test "$(uname -m)" = "arm64"
+
+      - name: Run Accelerate warning regressions
+        run: >-
+          pytest tests/test_matmul.py
+          -W error
+          -q
+
   declared-dependency-ranges:
     needs: change_scope
     if: needs.change_scope.outputs.run_tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
             uv.lock
 
       - name: Install regression-test dependencies
-        run: uv pip install -e ".[headless]" "numpy==2.2.6" "pytest>=9.0.3"
+        run: uv pip install -e ".[headless]" "numpy==2.2.6" -r requirements-dev.txt
 
       - name: Verify arm64 runner
         run: test "$(uname -m)" = "arm64"

--- a/albucore/ops_misc.py
+++ b/albucore/ops_misc.py
@@ -302,13 +302,9 @@ def matmul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """
     if (
         _IS_MACOS_ARM64
-        and (
-            a.shape[0] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
-            or a.shape[1] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
-            or b.shape[1] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
-        )
         and a.dtype.kind == "f"
         and b.dtype.kind == "f"
+        and max((*a.shape, *b.shape), default=0) >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
     ):
         with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
             return cast("np.ndarray", a @ b)

--- a/albucore/ops_misc.py
+++ b/albucore/ops_misc.py
@@ -1,5 +1,7 @@
 """Flips, median blur, matmul, pairwise distances."""
 
+import platform
+import sys
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, cast
@@ -21,6 +23,8 @@ from albucore.utils import (
 )
 
 MAX_OPENCV_FLIP_CHANNELS = get_opencv_max_channels()
+_IS_MACOS_ARM64 = sys.platform == "darwin" and platform.machine() == "arm64"
+_MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION = 16
 
 
 @contiguous
@@ -287,10 +291,28 @@ def matmul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
         this is the recommended replacement for cv2.gemm in geometric
         transformation contexts.
 
+        On macOS arm64, NumPy's Accelerate-backed kernels can emit spurious
+        divide, overflow, and invalid warnings for large finite floating-point
+        matrices. Those warning statuses are suppressed only on the affected
+        platform and size path; the computed values are returned unchanged.
+
         Use Cases:
         - ThinPlateSpline geometric transformation (3 uses in AlbumentationsX)
         - Macenko stain normalization for medical imaging (1 use in AlbumentationsX)
     """
+    if (
+        _IS_MACOS_ARM64
+        and (
+            a.shape[0] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
+            or a.shape[1] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
+            or b.shape[1] >= _MACOS_ACCELERATE_MATMUL_WARNING_MIN_DIMENSION
+        )
+        and a.dtype.kind == "f"
+        and b.dtype.kind == "f"
+    ):
+        with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+            return cast("np.ndarray", a @ b)
+
     return cast("np.ndarray", a @ b)
 
 
@@ -332,6 +354,9 @@ def pairwise_distances_squared(
         The computation can produce very small negative values (e.g., -1e-6)
         due to floating-point rounding with float32 inputs. The result is
         automatically clamped to enforce non-negativity (distances >= 0).
+
+        The large-set route uses :func:`matmul`, including its narrowly scoped
+        macOS arm64 workaround for spurious NumPy Accelerate warnings.
     """
     # Keep dtype normalization cheap; only force contiguity on the nk.cdist branch below.
     points1 = points1.astype(np.float32, copy=False)
@@ -349,10 +374,7 @@ def pairwise_distances_squared(
     # Vectorized: ||a-b||² = ||a||² + ||b||² - 2(a·b)
     p1_squared = (points1**2).sum(axis=1, keepdims=True)  # (N, 1)
     p2_squared = (points2**2).sum(axis=1)[None, :]  # (1, M)
-    # NumPy can emit spurious divide, overflow, and invalid warnings for tall
-    # float32 matmul inputs on macOS Accelerate even when the result is finite.
-    with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-        dot_product = points1 @ points2.T  # (N, M)
+    dot_product = matmul(points1, points2.T)  # (N, M)
 
     result = p1_squared + p2_squared - 2 * dot_product
     # Clamp to zero to handle numerical errors that can produce small negative values

--- a/albucore/ops_misc.py
+++ b/albucore/ops_misc.py
@@ -349,7 +349,10 @@ def pairwise_distances_squared(
     # Vectorized: ||a-b||² = ||a||² + ||b||² - 2(a·b)
     p1_squared = (points1**2).sum(axis=1, keepdims=True)  # (N, 1)
     p2_squared = (points2**2).sum(axis=1)[None, :]  # (1, M)
-    dot_product = points1 @ points2.T  # (N, M)
+    # NumPy can emit spurious divide, overflow, and invalid warnings for tall
+    # float32 matmul inputs on macOS Accelerate even when the result is finite.
+    with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+        dot_product = points1 @ points2.T  # (N, M)
 
     result = p1_squared + p2_squared - 2 * dot_product
     # Clamp to zero to handle numerical errors that can produce small negative values

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cv2
 import numpy as np
 import pytest
@@ -263,6 +265,24 @@ class TestPairwiseDistancesSquared:
             j = np.random.randint(0, 100)
             expected_dist = np.sum((points1[i] - points2[j]) ** 2)
             np.testing.assert_allclose(result[i, j], expected_dist, rtol=1e-5, atol=1e-6)
+
+    def test_tall_float32_inputs_do_not_emit_runtime_warnings(self) -> None:
+        """Verify finite tall inputs do not trigger spurious NumPy matmul warnings."""
+        points1 = np.linspace(0, 1, 4096 * 2, dtype=np.float32).reshape(4096, 2)
+        points2 = np.array(
+            [[0, 0], [0, 1], [1, 0], [1, 1], [0.5, 0.5]],
+            dtype=np.float32,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result = pairwise_distances_squared(points1, points2)
+
+        expected = ((points1[:, None, :] - points2[None, :, :]) ** 2).sum(axis=2)
+        np.testing.assert_equal(result.dtype, np.dtype(np.float32))
+        np.testing.assert_equal(np.isfinite(result).all(), True)
+        np.testing.assert_equal(np.all(result >= 0), True)
+        np.testing.assert_allclose(result, expected, rtol=1e-5, atol=2e-7)
 
     def test_edge_case_single_point(self) -> None:
         """Test with single points."""

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -117,7 +117,30 @@ class TestMatmul:
         expected = cv2.gemm(points, control_points.T, 1.0, None, 0.0)
         assert result.dtype == np.float32
         assert np.isfinite(result).all()
-        np.testing.assert_array_equal(result, expected)
+        np.testing.assert_allclose(result, expected, rtol=1e-4, atol=5e-5)
+
+    @pytest.mark.parametrize(
+        ("a_shape", "b_shape"),
+        [
+            ((32,), (32,)),
+            ((32,), (32, 2)),
+            ((2, 32), (32,)),
+        ],
+    )
+    def test_macos_warning_suppression_supports_vector_inputs(
+        self,
+        a_shape: tuple[int, ...],
+        b_shape: tuple[int, ...],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify the macOS warning gate preserves NumPy's vector matmul behavior."""
+        monkeypatch.setattr("albucore.ops_misc._IS_MACOS_ARM64", True)
+        a = np.arange(np.prod(a_shape), dtype=np.float32).reshape(a_shape)
+        b = np.arange(np.prod(b_shape), dtype=np.float32).reshape(b_shape)
+
+        result = matmul(a, b)
+
+        np.testing.assert_allclose(result, a @ b, rtol=1e-6, atol=1e-6)
 
 
 class TestPairwiseDistancesSquared:

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -102,6 +102,23 @@ class TestMatmul:
         expected = np.zeros((3, 5), dtype=np.float32)
         np.testing.assert_array_equal(result, expected)
 
+    def test_tall_float32_inputs_do_not_emit_runtime_warnings(self) -> None:
+        """Verify finite tall inputs do not trigger spurious NumPy matmul warnings."""
+        points = np.linspace(0, 1, 4096 * 2, dtype=np.float32).reshape(4096, 2)
+        control_points = np.array(
+            [[0, 0], [0, 1], [1, 0], [1, 1], [0.5, 0.5]],
+            dtype=np.float32,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result = matmul(points, control_points.T)
+
+        expected = cv2.gemm(points, control_points.T, 1.0, None, 0.0)
+        assert result.dtype == np.float32
+        assert np.isfinite(result).all()
+        np.testing.assert_array_equal(result, expected)
+
 
 class TestPairwiseDistancesSquared:
     """Test pairwise_distances_squared function."""
@@ -279,9 +296,9 @@ class TestPairwiseDistancesSquared:
             result = pairwise_distances_squared(points1, points2)
 
         expected = ((points1[:, None, :] - points2[None, :, :]) ** 2).sum(axis=2)
-        np.testing.assert_equal(result.dtype, np.dtype(np.float32))
-        np.testing.assert_equal(np.isfinite(result).all(), True)
-        np.testing.assert_equal(np.all(result >= 0), True)
+        assert result.dtype == np.float32
+        assert np.isfinite(result).all()
+        assert np.all(result >= 0)
         np.testing.assert_allclose(result, expected, rtol=1e-5, atol=2e-7)
 
     def test_edge_case_single_point(self) -> None:

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -117,6 +117,46 @@ def test_ci_matrix_requires_macos_arm64_warning_regressions(monkeypatch) -> None
     assert "CI workflow does not install test dependencies for the macOS regression tests" in errors
 
 
+def test_ci_matrix_accepts_equivalent_macos_dependency_formatting(monkeypatch) -> None:
+    ci_text = (
+        ci_matrix.CI_WORKFLOW.read_text()
+        .replace("runs-on: macos-latest", "runs-on: 'macos-latest'")
+        .replace(
+            'run: uv pip install -e ".[headless]" "numpy==2.2.6" -r requirements-dev.txt',
+            "run: uv pip install -e '.[headless]' 'numpy==2.2.6' --requirement=requirements-dev.txt",
+        )
+    )
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CI_WORKFLOW:
+            return ci_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    assert ci_matrix.check() == []
+
+
+def test_ci_matrix_requires_dev_dependencies_in_macos_job(monkeypatch) -> None:
+    ci_text = ci_matrix.CI_WORKFLOW.read_text().replace(
+        'run: uv pip install -e ".[headless]" "numpy==2.2.6" -r requirements-dev.txt',
+        'run: uv pip install -e ".[headless]" "numpy==2.2.6"',
+    )
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CI_WORKFLOW:
+            return ci_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert "CI workflow does not install test dependencies for the macOS regression tests" in errors
+
+
 def test_ci_matrix_requires_legal_artifact_verifier_commands(monkeypatch) -> None:
     release_candidate_text = ci_matrix.RELEASE_CANDIDATE_WORKFLOW.read_text().replace(
         ci_matrix.LEGAL_ARTIFACT_VERIFY_COMMAND,

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -88,7 +88,31 @@ def test_ci_matrix_requires_version_only_test_gating(monkeypatch) -> None:
     errors = ci_matrix.check()
 
     assert "CI workflow is missing version-only change classifier" in errors
-    assert "CI workflow does not gate both test jobs on change scope" in errors
+    assert "CI workflow does not gate all three test jobs on change scope" in errors
+
+
+def test_ci_matrix_requires_macos_arm64_warning_regressions(monkeypatch) -> None:
+    ci_text = (
+        ci_matrix.CI_WORKFLOW.read_text()
+        .replace("runs-on: macos-latest", "")
+        .replace("pytest tests/test_matmul.py", "")
+        .replace("-W error", "")
+        .replace('"numpy==2.2.6"', "")
+    )
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == ci_matrix.CI_WORKFLOW:
+            return ci_text
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    errors = ci_matrix.check()
+
+    assert "CI workflow is missing the macOS arm64 runner" in errors
+    assert "CI workflow is missing warnings-as-errors matmul tests on macOS" in errors
+    assert "CI workflow does not pin the affected NumPy version for the macOS regression tests" in errors
 
 
 def test_ci_matrix_requires_legal_artifact_verifier_commands(monkeypatch) -> None:

--- a/tests/test_verification_tools.py
+++ b/tests/test_verification_tools.py
@@ -98,6 +98,7 @@ def test_ci_matrix_requires_macos_arm64_warning_regressions(monkeypatch) -> None
         .replace("pytest tests/test_matmul.py", "")
         .replace("-W error", "")
         .replace('"numpy==2.2.6"', "")
+        .replace("-r requirements-dev.txt", "")
     )
     original_read_text = Path.read_text
 
@@ -113,6 +114,7 @@ def test_ci_matrix_requires_macos_arm64_warning_regressions(monkeypatch) -> None
     assert "CI workflow is missing the macOS arm64 runner" in errors
     assert "CI workflow is missing warnings-as-errors matmul tests on macOS" in errors
     assert "CI workflow does not pin the affected NumPy version for the macOS regression tests" in errors
+    assert "CI workflow does not install test dependencies for the macOS regression tests" in errors
 
 
 def test_ci_matrix_requires_legal_artifact_verifier_commands(monkeypatch) -> None:

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -92,6 +92,8 @@ def _check_ci(errors: list[str], versions: set[str]) -> None:
         errors.append("CI workflow is missing warnings-as-errors matmul tests on macOS")
     if '"numpy==2.2.6"' not in text:
         errors.append("CI workflow does not pin the affected NumPy version for the macOS regression tests")
+    if "-r requirements-dev.txt" not in text:
+        errors.append("CI workflow does not install test dependencies for the macOS regression tests")
     if "permissions:" not in text or "contents: read" not in text:
         errors.append("CI workflow must declare minimal GITHUB_TOKEN permissions")
 

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -84,8 +84,14 @@ def _check_ci(errors: list[str], versions: set[str]) -> None:
         errors.append("CI workflow does not run router contract check")
     if "python tools/classify_ci_changes.py" not in text:
         errors.append("CI workflow is missing version-only change classifier")
-    if text.count("if: needs.change_scope.outputs.run_tests == 'true'") != 2:
-        errors.append("CI workflow does not gate both test jobs on change scope")
+    if text.count("if: needs.change_scope.outputs.run_tests == 'true'") != 3:
+        errors.append("CI workflow does not gate all three test jobs on change scope")
+    if "runs-on: macos-latest" not in text:
+        errors.append("CI workflow is missing the macOS arm64 runner")
+    if "pytest tests/test_matmul.py" not in text or "-W error" not in text:
+        errors.append("CI workflow is missing warnings-as-errors matmul tests on macOS")
+    if '"numpy==2.2.6"' not in text:
+        errors.append("CI workflow does not pin the affected NumPy version for the macOS regression tests")
     if "permissions:" not in text or "contents: read" not in text:
         errors.append("CI workflow must declare minimal GITHUB_TOKEN permissions")
 

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -43,6 +43,14 @@ def _classifier_python_versions(classifiers: list[str]) -> set[str]:
     return versions
 
 
+def _workflow_job(text: str, job_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    return match.group(0) if match is not None else ""
+
+
 def _check_pyproject(errors: list[str]) -> set[str]:
     pyproject = _load_pyproject()
     project = pyproject.get("project", {})
@@ -73,6 +81,7 @@ def _check_pyproject(errors: list[str]) -> set[str]:
 
 def _check_ci(errors: list[str], versions: set[str]) -> None:
     text = CI_WORKFLOW.read_text()
+    macos_matmul_job = _workflow_job(text, "macos-arm64-matmul")
     errors.extend(
         f"CI matrix does not mention Python {version}"
         for version in sorted(versions)
@@ -86,13 +95,22 @@ def _check_ci(errors: list[str], versions: set[str]) -> None:
         errors.append("CI workflow is missing version-only change classifier")
     if text.count("if: needs.change_scope.outputs.run_tests == 'true'") != 3:
         errors.append("CI workflow does not gate all three test jobs on change scope")
-    if "runs-on: macos-latest" not in text:
+    if re.search(r"""runs-on:\s*["']?macos-latest["']?""", macos_matmul_job) is None:
         errors.append("CI workflow is missing the macOS arm64 runner")
-    if "pytest tests/test_matmul.py" not in text or "-W error" not in text:
+    if (
+        re.search(r"pytest\s+tests/test_matmul\.py", macos_matmul_job) is None
+        or re.search(r"-W\s+error", macos_matmul_job) is None
+    ):
         errors.append("CI workflow is missing warnings-as-errors matmul tests on macOS")
-    if '"numpy==2.2.6"' not in text:
+    if "numpy==2.2.6" not in macos_matmul_job:
         errors.append("CI workflow does not pin the affected NumPy version for the macOS regression tests")
-    if "-r requirements-dev.txt" not in text:
+    if (
+        re.search(
+            r"""(?:^|\s)(?:-r|--requirement)(?:\s+|=)["']?requirements-dev\.txt["']?(?=\s|$)""",
+            macos_matmul_job,
+        )
+        is None
+    ):
         errors.append("CI workflow does not install test dependencies for the macOS regression tests")
     if "permissions:" not in text or "contents: read" not in text:
         errors.append("CI workflow must declare minimal GITHUB_TOKEN permissions")


### PR DESCRIPTION
## Summary

- suppress spurious NumPy Accelerate floating-point warnings in both `matmul` and the large-input `pairwise_distances_squared` path
- apply the workaround only to floating-point arrays using larger kernels on macOS arm64
- keep the size guard dimension-agnostic so NumPy vector and batched matmul forms retain their native behavior
- route `pairwise_distances_squared` through the shared `matmul` implementation instead of duplicating warning handling
- document the platform-specific behavior and use tolerant cross-backend assertions in the regression tests
- add a dedicated `macos-latest` arm64 CI job using Python 3.10 and NumPy 2.2.6

## Root cause

On macOS arm64 with NumPy 2.2.6, Accelerate-backed matmul kernels can emit divide-by-zero, overflow, and invalid-value warnings for finite inputs even though the returned values are finite and correct. These warnings break callers that promote warnings to errors.

The workaround is limited to macOS arm64, floating-point inputs, and arrays with a dimension of at least 16—the observed boundary where Accelerate switches to affected kernels. Tiny calls keep the direct NumPy path. Computed values are returned unchanged.

## CI coverage

The new `macos-arm64-matmul` job:

- runs on `macos-latest`, which is an arm64 GitHub-hosted runner
- verifies the runner architecture explicitly
- installs the reported NumPy 2.2.6 environment
- runs the complete `tests/test_matmul.py` module with `-W error`

The CI policy checker scopes these requirements to the macOS job and accepts semantically equivalent YAML quoting and requirement syntax.

## Performance

The shared workaround adds no array passes, copies, conversions, or result allocations. The duplicate pairwise warning context was removed. The affected public `matmul` path adds a scoped error-state context; its absolute dispatch cost is sub-microsecond to about 1.1 μs in these local runs.

Local public-path timings on macOS arm64:

| Path | Shape | Before | After |
| --- | --- | ---: | ---: |
| `matmul` | 2×2×2 | 0.000417 ms | 0.000770 ms |
| `matmul` | 10×10×10 | 0.000602 ms | 0.000972 ms |
| `matmul` | 128×64×32 | 0.001507 ms | 0.002644 ms |
| `matmul` | 4096×2×5 | 0.014183 ms | 0.014905 ms |
| `matmul` | 262144×2×10 | 0.572988 ms | 0.563254 ms |
| pairwise distances | 4096×5×2 | 0.075879 ms | 0.075873 ms |
| pairwise distances | 262144×10×2 | 5.300715 ms | 5.378531 ms |

Backend routing and allocation behavior are unchanged.

## Validation

- `uv run pytest tests/test_matmul.py -W error -q` — 44 passed
- `uv run pytest -q` — 1,957 passed
- `uv run mypy albucore`
- `uv run python tools/ci_matrix.py check`
- all pre-commit hooks passed

Fixes #126
