### PR TITLE
chore(release): bump version to 0.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.7"
+version = "0.2.8"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from 0.2.7 to 0.2.8
- keep the locked editable package metadata in sync

## Why

Prepare the next patch release after the fixes merged since 0.2.7.

## Impact

Package metadata now reports version 0.2.8. There are no runtime API or behavior changes in this PR.

## Validation

- `uv lock --check`
- `uv run pytest` (1,957 passed)
- `pre-commit run --all-files`

## Summary by Sourcery

Bump Albucore package version to 0.2.8 and refresh the lockfile to keep editable package metadata in sync.

Build:
- Update project version in pyproject.toml to 0.2.8 and align uv.lock metadata accordingly.

Chores:
- Prepare repository for the 0.2.8 patch release with updated versioning metadata.