### PR TITLE
chore(release): bump version to 0.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.8"
+version = "0.2.9"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from `0.2.8` to `0.2.9`
- keep the editable package metadata in `uv.lock` synchronized

## Impact

Prepares the repository metadata for the `0.2.9` patch release. There are no runtime behavior changes.

## Validation

- `uv lock --check`
- `uv run pytest` (2,040 passed)
- `pre-commit run --all-files`

## Summary by Sourcery

Prepare project metadata for the 0.2.9 patch release of the albucore package.

Chores:
- Bump albucore package version from 0.2.8 to 0.2.9 in project configuration.
- Synchronize editable package metadata in uv.lock with the new release version.