### PR TITLE
chore(release): bump version to 0.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.10"
+version = "0.2.11"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore package version from `0.2.10` to `0.2.11`
- keep the editable package entry in `uv.lock` aligned with `pyproject.toml`

## Why

Prepare the next patch release so package artifacts and dependency metadata publish as version `0.2.11`. This changes release metadata only and does not alter runtime behavior.

## Validation

- `uv lock --check`
- built/imported package reports `albucore.__version__ == "0.2.11"`
- configured pre-commit checks passed during commit

## Summary by Sourcery

Bump the albucore package to version 0.2.11 and align lockfile metadata with the new release version.

Build:
- Update project version metadata in pyproject.toml and corresponding uv.lock entry for the 0.2.11 release.

Chores:
- Prepare release metadata for the 0.2.11 patch version without changing runtime behavior.