### PR TITLE
chore(release): bump version to 0.2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.11"
+version = "0.2.12"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- Bump Albucore from `0.2.11` to `0.2.12`.
- Refresh `uv.lock` release metadata.

## Validation

- `uv lock --check`
- `uv run pytest` (2,181 passed)
- `pre-commit run --all-files`

## Summary by Sourcery

Bump project version for a new release and update dependency lock metadata.

Build:
- Increment albucore package version to 0.2.12 in pyproject configuration.

Chores:
- Refresh uv.lock to capture updated release metadata without functional code changes.