### PR TITLE
test(utils): cover image-channel predicates

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -315,6 +315,29 @@ def test_is_grayscale_image(shape, expected_grayscale, description):
 
 
 @pytest.mark.parametrize(
+    ("shape", "expected_rgb", "expected_multispectral"),
+    [
+        ((100, 200, 1), False, False),
+        ((100, 200, 3), True, False),
+        ((100, 200, 4), False, True),
+        ((100, 200, 5), False, True),
+        ((10, 100, 200, 1), False, False),
+        ((10, 100, 200, 3), True, False),
+        ((10, 100, 200, 4), False, True),
+        ((10, 100, 200, 5), False, True),
+    ],
+)
+def test_image_channel_predicates(
+    shape: tuple[int, ...], expected_rgb: bool, expected_multispectral: bool
+) -> None:
+    """Test RGB and multispectral channel predicates for HWC and XHWC arrays."""
+    image = np.zeros(shape, dtype=np.uint8)
+
+    assert is_rgb_image(image) is expected_rgb
+    assert is_multispectral_image(image) is expected_multispectral
+
+
+@pytest.mark.parametrize(
     "shape",
     [
         # Basic HWC cases


### PR DESCRIPTION
## Summary

Adds direct unit coverage for `is_rgb_image` and `is_multispectral_image`.

The matrix covers HWC and XHWC shapes with 1, 3, 4, and 5 channels, asserting the complete predicate truth table. This keeps the low-level contract tested in Albucore after the upstream re-export coverage was removed.

Closes #141.

## Validation

- `uv run pytest` — 2062 passed
- `pre-commit run --all-files` — passed

## Summary by Sourcery

Tests:
- Add parameterized tests for is_rgb_image and is_multispectral_image over HWC and XHWC shapes with varying channel counts.