### PR TITLE
chore(release): bump version to 0.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.12"
+version = "0.2.13"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the Albucore patch version from 0.2.12 to 0.2.13
- synchronize the editable-package version in `uv.lock`

## Validation

- `uv lock --check`
- `uv run pytest` (2068 passed)
- `pre-commit run --all-files`

## Summary by Sourcery

Build:
- Update pyproject.toml to set the Albucore package version to 0.2.13.