### PR TITLE
docs: reference AlbumentationsX preprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 [![Python 3.10+](https://img.shields.io/pypi/pyversions/albucore.svg)](https://pypi.org/project/albucore/)
 [![CI](https://github.com/albumentations-team/albucore/actions/workflows/ci.yml/badge.svg)](https://github.com/albumentations-team/albucore/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Sponsored by GitAds](https://gitads.dev/v1/ad-serve?source=albumentations-team/albucore@github)](https://gitads.dev/v1/ad-track?source=albumentations-team/albucore@github)
-
 Albucore is a library of optimized atomic functions designed for efficient image processing. These functions serve as the foundation for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), an image augmentation library.
+
+> 📚 **AlbumentationsX research paper:** If you use Albucore as part of an AlbumentationsX pipeline, please cite
+> the [AlbumentationsX preprint](https://arxiv.org/abs/2608.11123). Citations make the project's research impact
+> visible to funders and help sustain maintenance. The BibTeX entry is in [Citing AlbumentationsX](#citing-albumentationsx).
 
 ## Overview
 
@@ -266,4 +268,19 @@ CLA Assistant and entity acceptance paths.
 
 Albucore provides core image-processing primitives for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX). We'd like to thank all [AlbumentationsX contributors](https://albumentations.ai/people) and the broader computer vision community for their inspiration and support.
 
-<!-- GitAds-Verify: 1LSAKH1Y2GKIISALRDIFCG2T9YYNR5WD -->
+## Citing AlbumentationsX
+
+If you use Albucore as part of an AlbumentationsX pipeline, please cite
+[AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations](https://arxiv.org/abs/2608.11123).
+Your citation makes the project's research impact visible to funders and helps sustain maintenance.
+
+```bibtex
+@article{iglovikov2026albumentationsx,
+    title = {AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations},
+    author = {Iglovikov, Vladimir},
+    journal = {arXiv preprint arXiv:2608.11123},
+    year = {2026},
+    doi = {10.48550/arXiv.2608.11123},
+    url = {https://arxiv.org/abs/2608.11123}
+}
+```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 Albucore is a library of optimized atomic functions designed for efficient image processing. These functions serve as the foundation for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), an image augmentation library.
 
-> 📚 **AlbumentationsX research paper:** If you use Albucore as part of an AlbumentationsX pipeline, please cite
-> the [AlbumentationsX preprint](https://arxiv.org/abs/2608.11123). Citations make the project's research impact
-> visible to funders and help sustain maintenance. The BibTeX entry is in [Citing AlbumentationsX](#citing-albumentationsx).
+## Citing AlbumentationsX
+
+If you use Albucore as part of an AlbumentationsX pipeline, please cite
+[AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations](https://arxiv.org/abs/2608.11123).
+Your citation makes the project's research impact visible to funders and helps sustain maintenance.
+
+```bibtex
+@article{iglovikov2026albumentationsx,
+    title = {AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations},
+    author = {Iglovikov, Vladimir},
+    journal = {arXiv preprint arXiv:2608.11123},
+    year = {2026},
+    doi = {10.48550/arXiv.2608.11123},
+    url = {https://arxiv.org/abs/2608.11123}
+}
+```
 
 ## Overview
 
@@ -267,20 +280,3 @@ CLA Assistant and entity acceptance paths.
 ## Acknowledgements
 
 Albucore provides core image-processing primitives for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX). We'd like to thank all [AlbumentationsX contributors](https://albumentations.ai/people) and the broader computer vision community for their inspiration and support.
-
-## Citing AlbumentationsX
-
-If you use Albucore as part of an AlbumentationsX pipeline, please cite
-[AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations](https://arxiv.org/abs/2608.11123).
-Your citation makes the project's research impact visible to funders and helps sustain maintenance.
-
-```bibtex
-@article{iglovikov2026albumentationsx,
-    title = {AlbumentationsX: One Augmentation Pipeline for Images and Related Annotations},
-    author = {Iglovikov, Vladimir},
-    journal = {arXiv preprint arXiv:2608.11123},
-    year = {2026},
-    doi = {10.48550/arXiv.2608.11123},
-    url = {https://arxiv.org/abs/2608.11123}
-}
-```


### PR DESCRIPTION
## Summary

- link the AlbumentationsX preprint for users who use Albucore through an AlbumentationsX pipeline
- add the corresponding BibTeX entry
- remove the GitAds badge and verification marker

## Why

The preprint describes AlbumentationsX rather than Albucore as a standalone library, so the citation request is explicitly limited to Albucore's use within an AlbumentationsX pipeline. Citations document the project's research impact for grant applications and maintenance.

## Validation

- `pre-commit run --files README.md`

## Summary by Sourcery

Document AlbumentationsX citation guidance for Albucore users and clean up third-party advertising from the README.

Documentation:
- Add a README section explaining when and how to cite the AlbumentationsX preprint, including a BibTeX entry for the paper.

Chores:
- Remove the GitAds sponsorship badge and verification marker from the README.