### PR TITLE
chore(quality): protect Ruff complexity rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,11 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/ternaus/ruff-policy-hooks
+    rev: v0.4.0
+    hooks:
+      - id: check-ruff-suppressions
+        args: [--protect=C901,PLR0912,PLR0913,PLR0915,PLR0917]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,9 @@ repos:
     rev: v0.4.0
     hooks:
       - id: check-ruff-suppressions
+        # Keep this list aligned with the protected Ruff rules in pyproject.toml.
+        # The hook follows pyproject.toml per-file-ignores for intentional exceptions.
+        exclude: ^(benchmarks|tests|tools)/
         args: [--protect=C901,PLR0912,PLR0913,PLR0915,PLR0917]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2

--- a/albucore/affine3d.py
+++ b/albucore/affine3d.py
@@ -1,4 +1,3 @@
-# ruff: noqa: PLR0913  # The public OpenCV-compatible signature and internal kernel contract need these parameters.
 """True 3D affine resampling for single NumPy and Torch volumes."""
 
 from __future__ import annotations

--- a/albucore/geometric.py
+++ b/albucore/geometric.py
@@ -5,7 +5,6 @@ Chunking when OpenCV limits apply. blur, GaussianBlur, medianBlur, resize, filte
 work out of the box for >4ch — use cv2 directly.
 OpenCV channel limits: see ``benchmarks/README.md``.
 """
-# ruff: noqa: PLR0911 PLR0913  # chunked fns need many args
 
 from collections.abc import Callable
 from typing import cast, overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,8 +147,6 @@ lint.ignore = [
   "FBT001",
   "FBT002",
   "FBT003",
-  # Public OpenCV-compatible APIs intentionally have more than five parameters.
-  "PLR0917",
   "PLR2004",
   "TRY003",
 ]
@@ -162,6 +160,13 @@ lint.unfixable = [  ]
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Like Black, use double quotes for strings.
 lint.pydocstyle.convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# These modules expose drop-in OpenCV-compatible signatures and internal helpers
+# that mirror those signatures. Keep the argument-count exceptions scoped to
+# those implementation modules rather than disabling the rules globally.
+"albucore/affine3d.py" = [ "PLR0913", "PLR0917" ]
+"albucore/geometric.py" = [ "PLR0911", "PLR0913", "PLR0917" ]
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,8 @@ lint.pydocstyle.convention = "google"
 # These modules expose drop-in OpenCV-compatible signatures and internal helpers
 # that mirror those signatures. Keep the argument-count exceptions scoped to
 # those implementation modules rather than disabling the rules globally.
+# The policy hook follows these exact path-scoped exceptions; update this table
+# if either module moves so Ruff and the policy hook stay aligned.
 "albucore/affine3d.py" = [ "PLR0913", "PLR0917" ]
 "albucore/geometric.py" = [ "PLR0911", "PLR0913", "PLR0917" ]
 


### PR DESCRIPTION
## Summary

- Add `ruff-policy-hooks` v0.4.0 to protect `C901`, `PLR0912`, `PLR0913`, `PLR0915`, and `PLR0917` from new suppressions.
- Scope the existing argument-count exceptions to the OpenCV-compatible geometry modules instead of disabling `PLR0917` globally.
- Preserve the public API while preventing new complexity suppressions elsewhere.

## Validation

- `pytest tests/ --hypothesis-profile=ci-fast` — 2040 passed
- `pre-commit run --all-files --show-diff-on-failure` — passed

## Summary by Sourcery

Enforce Ruff complexity-suppression policy without changing the public API or intentional geometry-module exceptions.

Enhancements:
- Protect Ruff complexity and argument-count rules from new suppressions while retaining scoped exceptions for OpenCV-compatible geometry APIs.

CI:
- Add a pre-commit policy hook to enforce protected Ruff suppression rules.

Chores:
- Remove file-level Ruff suppression directives and replace the global PLR0917 ignore with path-scoped exceptions.