### PR TITLE
chore(release): bump version to 0.2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.13"
+version = "0.2.14"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.13"
+version = "0.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
Bump Albucore from 0.2.13 to 0.2.14 and synchronize uv.lock. Validation: uv run pytest (2227 passed); pre-commit run --all-files passed.

## Summary by Sourcery

Build:
- Bump the Albucore package version to 0.2.14 and synchronize the uv lockfile.