### PR TITLE
chore(release): bump version to 0.2.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.14"
+version = "0.2.15"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.14"
+version = "0.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- Bump the package version from `0.2.14` to `0.2.15`.
- Update the editable package version in `uv.lock`.

## Validation

- `uv lock --check`
- `uv run pytest` — 2285 passed
- `pre-commit run --all-files`

## Summary by Sourcery

Build:
- Bump the package version to 0.2.15 and update the lockfile accordingly.