### PR TITLE
chore(release): bump version to 0.2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.15"
+version = "0.2.16"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- Bump Albucore from 0.2.15 to 0.2.16.
- Keep the package metadata and lockfile versions aligned.

## Validation

- `uv lock --check`
- `uv run pytest` (2243 passed)
- `pre-commit run --all-files

## Summary by Sourcery

Chores:
- Bump the Albucore package version to 0.2.16 and keep the lockfile metadata aligned.