### PR TITLE
chore(release): prepare 0.2.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "albucore"
-version = "0.2.17"
+version = "0.2.18"
 
 description = "High-performance image processing functions for deep learning and computer vision."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.2.17"
+version = "0.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "numkong" },


### PR DESCRIPTION
## Summary

- bump the package version from 0.2.17 to 0.2.18
- keep the editable Albucore entry in uv.lock synchronized

## Validation

- uv lock --check
- uv run pytest (2440 passed)
- pre-commit run --all-files

## Summary by Sourcery

Build:
- Bump the package version to 0.2.18 and synchronize the locked editable package metadata.